### PR TITLE
KP-1yul Gas optimisation using standalone yul

### DIFF
--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -6,7 +6,10 @@ import "forge-std/Vm.sol";
 Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
 function newGasContract(address[] memory _admins, uint256 _totalSupply) returns (GasContract) {
-    bytes memory bytecode = bytes.concat(vm.getCode("Gas.sol:GasContractImpl"));
+    //vm.getCode doesn't work with yul targets for some reason so extract the bytecode manually
+    //bytes memory bytecode = bytes.concat(vm.getCode("GasContractYul.yul:GasContractImpl_39435"));
+    string memory path = string.concat(vm.projectRoot(), "/out/GasContractYul.yul/GasContractImpl_39435.json");
+    bytes memory bytecode = vm.parseJsonBytes(vm.readFile(path), ".bytecode.object");
     bytes memory ctorArgs = abi.encode(_admins, _totalSupply);
     bytes memory payload = bytes.concat(bytecode, ctorArgs);
     address addr;

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -2,10 +2,24 @@
 pragma solidity ^0.8.0;
 
 function newGasContract(address[] memory _admins, uint256 _totalSupply) returns (GasContract) {
-    return new GasContract(_admins, _totalSupply);
+    return new GasContractImpl(_admins, _totalSupply);
 }
 
-contract GasContract {
+interface GasContract {
+    event AddedToWhitelist(address userAddress, uint256 tier);
+    event WhiteListTransfer(address indexed);
+    function administrators(uint256 _index) external view returns (address admin_);
+    function checkForAdmin(address _user) external pure returns (bool admin_);
+    function balanceOf(address _user) external view returns (uint256 balance_);
+    function balances(address _user) external view returns (uint256 balance_);
+    function whitelist(address) external pure returns (uint256);
+    function transfer(address _recipient, uint256 _amount, string calldata) external payable;
+    function addToWhitelist(address _userAddrs, uint256 _tier) external payable;
+    function whiteTransfer(address _recipient, uint256 _amount) external payable;
+    function getPaymentStatus(address) external view returns (bool, uint256);
+}
+
+contract GasContractImpl is GasContract {
     mapping(address => uint256) private the_balances;
     uint256 whiteListAmount;
     address immutable admin0;
@@ -14,9 +28,6 @@ contract GasContract {
     address immutable admin3;
     address constant admin4 = address(0x1234);
     uint256 constant totalSupply = 1000000000;
-
-    event AddedToWhitelist(address userAddress, uint256 tier);
-    event WhiteListTransfer(address indexed);
 
     modifier onlyAdminOrOwner() {
         if (!checkForAdmin(msg.sender)) revert();

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -7,8 +7,8 @@ Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
 function newGasContract(address[] memory _admins, uint256 _totalSupply) returns (GasContract) {
     //vm.getCode doesn't work with yul targets for some reason so extract the bytecode manually
-    //bytes memory bytecode = bytes.concat(vm.getCode("GasContractYul.yul:GasContractImpl_39435"));
-    string memory path = string.concat(vm.projectRoot(), "/out/GasContractYul.yul/GasContractImpl_39435.json");
+    //bytes memory bytecode = bytes.concat(vm.getCode("GasContractYul.yul:GasContractYul"));
+    string memory path = string.concat(vm.projectRoot(), "/out/GasContractYul.yul/GasContractYul.json");
     bytes memory bytecode = vm.parseJsonBytes(vm.readFile(path), ".bytecode.object");
     bytes memory ctorArgs = abi.encode(_admins, _totalSupply);
     bytes memory payload = bytes.concat(bytecode, ctorArgs);

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
+function newGasContract(address[] memory _admins, uint256 _totalSupply) returns (GasContract) {
+    return new GasContract(_admins, _totalSupply);
+}
+
 contract GasContract {
     mapping(address => uint256) private the_balances;
     uint256 whiteListAmount;

--- a/src/Gas.sol
+++ b/src/Gas.sol
@@ -1,8 +1,18 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
+import "forge-std/Vm.sol";
+
+Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
 function newGasContract(address[] memory _admins, uint256 _totalSupply) returns (GasContract) {
-    return new GasContractImpl(_admins, _totalSupply);
+    bytes memory bytecode = bytes.concat(vm.getCode("Gas.sol:GasContractImpl"));
+    bytes memory ctorArgs = abi.encode(_admins, _totalSupply);
+    bytes memory payload = bytes.concat(bytecode, ctorArgs);
+    address addr;
+    assembly { addr := create(0, add(payload, 0x20), mload(payload)) }
+    require(addr != address(0), "could not deploy contract");
+    return GasContract(addr);
 }
 
 interface GasContract {

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -178,7 +178,6 @@ object "GasContractYul" {
 					}
 					case 0x70a08231 { external_fun_balances() }
 					case 0x888b2284 {
-						if callvalue() { revert(0, 0) }
 						if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
 						pop(abi_decode_address())
 						let _2 := sload(0x01)
@@ -190,7 +189,6 @@ object "GasContractYul" {
 						return(memPos, 64)
 					}
 					case 0x9b19251a {
-						if callvalue() { revert(0, 0) }
 						if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
 						pop(abi_decode_address())
 						let memPos_1 := mload(64)
@@ -198,7 +196,6 @@ object "GasContractYul" {
 						return(memPos_1, 32)
 					}
 					case 0xb52d15e2 {
-						if callvalue() { revert(0, 0) }
 						if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
 
 						let var_admin := eq(0x1234, and(abi_decode_address(), sub(shl(160, 1), 1)))
@@ -207,7 +204,6 @@ object "GasContractYul" {
 						return(memPos_2, 32)
 					}
 					case 0xd89d1510 {
-						if callvalue() { revert(0, 0) }
 						if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
 						let ret := fun_administrators(calldataload(4))
 						let memPos_3 := mload(64)
@@ -236,7 +232,6 @@ object "GasContractYul" {
 			}
 			function external_fun_balances()
 			{
-				if callvalue() { revert(0, 0) }
 				if slt(add(calldatasize(), not(3)), 32)
 				{
 					revert(0, 0)

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -2,69 +2,15 @@
 object "GasContractYul" {
 	code {
 		{
-			mstore(64, memoryguard(0x0100))
-			let programSize := datasize("GasContractYul")
-			let argSize := sub(codesize(), programSize)
-			let memoryDataOffset := allocate_memory(argSize)
-			codecopy(memoryDataOffset, programSize, argSize)
-
-			let offset := mload(memoryDataOffset)
-
-			let _2 := add(memoryDataOffset, offset)
-
-			let length := mload(_2)
-			let _3 := shl(5, length)
-			let dst := allocate_memory(add(_3, 0x20))
-			let array := dst
-			mstore(dst, length)
-			dst := add(dst, 0x20)
-			let dst_1 := dst
-			let srcEnd := add(add(_2, _3), 0x20)
-
-			let src := add(_2, 0x20)
-			for { } lt(src, srcEnd) { src := add(src, 0x20) }
-			{
-				let value := mload(src)
-				mstore(dst, value)
-				dst := add(dst, 0x20)
-			}
-
-			let addr := 0
-			addr := dst_1
-			mstore(128, and(mload(dst_1), sub(shl(160, 1), 1)))
-
-			let addr_1 := 0
-			addr_1 := add(array, 64)
-			mstore(160, and(mload(addr_1), sub(shl(160, 1), 1)))
-
-			let addr_2 := 0
-			addr_2 := add(array, 96)
-			mstore(192, and(mload(addr_2), sub(shl(160, 1), 1)))
-
-			let addr_3 := 0
-			addr_3 := add(array, 128)
-			mstore(224, and(mload(addr_3), sub(shl(160, 1), 1)))
-			let _4 := mload(64)
-			let _5 := datasize("GasContractYul_deployed")
-			codecopy(_4, dataoffset("GasContractYul_deployed"), _5)
-			setimmutable(_4, "39177", mload(128))
-			setimmutable(_4, "39179", mload(160))
-			setimmutable(_4, "39181", mload(192))
-			setimmutable(_4, "39183", mload(224))
-
-			return(_4, _5)
-		}
-		function allocate_memory(size) -> memPtr
-		{
-			memPtr := mload(64)
-			let newFreePtr := add(memPtr, and(add(size, 31), not(31)))
-			if or(gt(newFreePtr, sub(shl(64, 1), 1)), lt(newFreePtr, memPtr))
-			{
-				mstore(0, shl(224, 0x4e487b71))
-				mstore(4, 0x41)
-				revert(0, 0x24)
-			}
-			mstore(64, newFreePtr)
+			// ctor args are (address[] A, uint256 B)
+			// [64, B, A.length, A[0], A[1], A[2], A[3], ...]
+			let _offset := dataoffset("GasContractYul_deployed")
+			let _size := datasize("GasContractYul_deployed")
+			let _admins := add(add(_offset, _size), 96)
+			let _total := add(_size, 128)
+			codecopy(0, _offset, _size)
+			codecopy(_size, _admins, 128)
+			return(0, _total)
 		}
 	}
 
@@ -115,8 +61,12 @@ object "GasContractYul" {
 					}
 					case 0xd89d1510 {
 						// adminstrators
-						mstore(0, fun_administrators(calldataload(4)))
-						return(0, 32)
+						let _index := calldataload(4)
+						let _offset := add(datasize("GasContractYul_deployed"), shl(5, _index))
+						codecopy(0, _offset, 32)
+						mstore(32, 0x1234)
+						let _return := shl(5, eq(_index, 4))
+						return(_return, 32)
 					}
 					case 0xea28d320 {
 						// whiteTransfer
@@ -139,32 +89,6 @@ object "GasContractYul" {
 				var_balance := add(var_balance, mul(eq(_user, 0x1234), 0x3b9aca00))
 				mstore(0, var_balance)
 				return(0, 32)
-			}
-
-			function fun_administrators(var_index) -> var_admin
-			{
-				var_admin := 0
-				if iszero(var_index)
-				{
-					var_admin := loadimmutable("39177")
-					leave
-				}
-				if eq(var_index, 0x01)
-				{
-					var_admin := loadimmutable("39179")
-					leave
-				}
-				if eq(var_index, 0x02)
-				{
-					var_admin := loadimmutable("39181")
-					leave
-				}
-				if eq(var_index, 0x03)
-				{
-					var_admin := loadimmutable("39183")
-					leave
-				}
-				var_admin := 0x1234
 			}
 
 			function fun_transferImpl(var_recipient, var_amount)

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -232,31 +232,12 @@ object "GasContractYul" {
 			}
 			function external_fun_balances()
 			{
-				if slt(add(calldatasize(), not(3)), 32)
-				{
-					revert(0, 0)
-				}
-
-				let value0 := abi_decode_address()
-
-				let var_balance := 0
-
-				let _1 := and(value0, sub(shl(160, 1), 1))
+				let _1 := calldataload(4)
 				mstore(0, _1)
-				mstore(32, 0)
-
-				var_balance := sload(keccak256(0, 0x40))
-
-				if eq(_1, 0x1234)
-
-				{
-
-					var_balance := add(var_balance, 0x3b9aca00)
-				}
-
-				let memPos := mload(0x40)
-				mstore(memPos, var_balance)
-				return(memPos, 32)
+				let var_balance := sload(keccak256(0, 0x40))
+				var_balance := add(var_balance, mul(eq(_1, 0x1234), 0x3b9aca00))
+				mstore(0, var_balance)
+				return(0, 32)
 			}
 
 			function fun_administrators(var_index) -> var_admin

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -1,0 +1,329 @@
+/// @use-src 23:"src/Gas.sol"
+object "GasContractImpl_39435" {
+    code {
+        {
+            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+            mstore(64, memoryguard(0x0100))
+            let programSize := datasize("GasContractImpl_39435")
+            let argSize := sub(codesize(), programSize)
+            let memoryDataOffset := allocate_memory(argSize)
+            codecopy(memoryDataOffset, programSize, argSize)
+            let _1 := add(memoryDataOffset, argSize)
+            if slt(sub(_1, memoryDataOffset), 64)
+            {
+                revert(/** @src -1:-1:-1 */ 0, 0)
+            }
+            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+            let offset := mload(memoryDataOffset)
+            if gt(offset, sub(shl(64, 1), 1))
+            {
+                revert(/** @src -1:-1:-1 */ 0, 0)
+            }
+            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+            let _2 := add(memoryDataOffset, offset)
+            if iszero(slt(add(_2, 0x1f), _1))
+            {
+                revert(/** @src -1:-1:-1 */ 0, 0)
+            }
+            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+            let length := mload(_2)
+            if gt(length, sub(shl(64, 1), 1))
+            {
+                mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
+                mstore(4, 0x41)
+                revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
+            }
+            let _3 := shl(5, length)
+            let dst := allocate_memory(add(_3, 0x20))
+            let array := dst
+            mstore(dst, length)
+            dst := add(dst, 0x20)
+            let dst_1 := dst
+            let srcEnd := add(add(_2, _3), 0x20)
+            if gt(srcEnd, _1)
+            {
+                revert(/** @src -1:-1:-1 */ 0, 0)
+            }
+            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+            let src := add(_2, 0x20)
+            for { } lt(src, srcEnd) { src := add(src, 0x20) }
+            {
+                let value := mload(src)
+                if iszero(eq(value, and(value, sub(shl(160, 1), 1))))
+                {
+                    revert(/** @src -1:-1:-1 */ 0, 0)
+                }
+                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+                mstore(dst, value)
+                dst := add(dst, 0x20)
+            }
+            /// @src 23:2034:2044  "_admins[0]"
+            let addr := /** @src -1:-1:-1 */ 0
+            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+            if iszero(mload(array))
+            {
+                mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
+                mstore(4, 0x32)
+                revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
+            }
+            addr := dst_1
+            /// @src 23:2025:2044  "admin0 = _admins[0]"
+            mstore(128, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(mload(dst_1), sub(shl(160, 1), 1)))
+            /// @src 23:2063:2073  "_admins[1]"
+            let addr_1 := /** @src -1:-1:-1 */ 0
+            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+            if iszero(lt(/** @src 23:2071:2072  "1" */ 0x01, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ mload(array)))
+            {
+                mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
+                mstore(4, 0x32)
+                revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
+            }
+            addr_1 := add(array, 64)
+            /// @src 23:2054:2073  "admin1 = _admins[1]"
+            mstore(160, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(mload(addr_1), sub(shl(160, 1), 1)))
+            /// @src 23:2092:2102  "_admins[2]"
+            let addr_2 := /** @src -1:-1:-1 */ 0
+            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+            if iszero(lt(/** @src 23:2100:2101  "2" */ 0x02, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ mload(array)))
+            {
+                mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
+                mstore(4, 0x32)
+                revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
+            }
+            addr_2 := add(array, 96)
+            /// @src 23:2083:2102  "admin2 = _admins[2]"
+            mstore(192, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(mload(addr_2), sub(shl(160, 1), 1)))
+            /// @src 23:2121:2131  "_admins[3]"
+            let addr_3 := /** @src -1:-1:-1 */ 0
+            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+            if iszero(lt(/** @src 23:2129:2130  "3" */ 0x03, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ mload(array)))
+            {
+                mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
+                mstore(4, 0x32)
+                revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
+            }
+            addr_3 := add(array, /** @src 23:2025:2044  "admin0 = _admins[0]" */ 128)
+            /// @src 23:2112:2131  "admin3 = _admins[3]"
+            mstore(224, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(mload(addr_3), sub(shl(160, 1), 1)))
+            let _4 := mload(64)
+            let _5 := datasize("GasContractImpl_39435_deployed")
+            codecopy(_4, dataoffset("GasContractImpl_39435_deployed"), _5)
+            setimmutable(_4, "39177", mload(/** @src 23:2025:2044  "admin0 = _admins[0]" */ 128))
+            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+            setimmutable(_4, "39179", mload(/** @src 23:2054:2073  "admin1 = _admins[1]" */ 160))
+            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+            setimmutable(_4, "39181", mload(/** @src 23:2083:2102  "admin2 = _admins[2]" */ 192))
+            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+            setimmutable(_4, "39183", mload(/** @src 23:2112:2131  "admin3 = _admins[3]" */ 224))
+            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+            return(_4, _5)
+        }
+        function allocate_memory(size) -> memPtr
+        {
+            memPtr := mload(64)
+            let newFreePtr := add(memPtr, and(add(size, 31), not(31)))
+            if or(gt(newFreePtr, sub(shl(64, 1), 1)), lt(newFreePtr, memPtr))
+            {
+                mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
+                mstore(4, 0x41)
+                revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
+            }
+            mstore(64, newFreePtr)
+        }
+    }
+    /// @use-src 23:"src/Gas.sol"
+    object "GasContractImpl_39435_deployed" {
+        code {
+            {
+                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+                let _1 := memoryguard(0x80)
+                mstore(64, _1)
+                if iszero(lt(calldatasize(), 4))
+                {
+                    switch shr(224, calldataload(0))
+                    case 0x214405fc {
+                        if slt(add(calldatasize(), not(3)), 64) { revert(0, 0) }
+                        let value0 := abi_decode_address()
+                        let value := calldataload(36)
+                        /// @src 23:1896:1936  "if (!checkForAdmin(msg.sender)) revert()"
+                        if /** @src 23:1900:1926  "!checkForAdmin(msg.sender)" */ iszero(/** @src 23:2508:2523  "admin4 == _user" */ eq(/** @src 23:1797:1803  "0x1234" */ 0x1234, /** @src 23:1915:1925  "msg.sender" */ caller()))
+                        /// @src 23:1896:1936  "if (!checkForAdmin(msg.sender)) revert()"
+                        {
+                            /// @src 23:1928:1936  "revert()"
+                            revert(/** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0, 0)
+                        }
+                        if iszero(/** @src 23:3754:3765  "_tier < 255" */ lt(value, /** @src 23:3762:3765  "255" */ 0xff))
+                        /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+                        { revert(0, 0) }
+                        mstore(_1, and(value0, sub(shl(160, 1), 1)))
+                        mstore(add(_1, 32), value)
+                        /// @src 23:3870:3905  "AddedToWhitelist(_userAddrs, _tier)"
+                        log1(_1, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 64, /** @src 23:3870:3905  "AddedToWhitelist(_userAddrs, _tier)" */ 0x62c1e066774519db9fe35767c15fc33df2f016675b7cc0c330ed185f286a2d52)
+                        /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+                        return(0, 0)
+                    }
+                    case 0x27e235e3 { external_fun_balances() }
+                    case 0x56b8c724 {
+                        if slt(add(calldatasize(), not(3)), 96) { revert(0, 0) }
+                        let value0_1 := abi_decode_address()
+                        let offset := calldataload(68)
+                        if gt(offset, sub(shl(64, 1), 1)) { revert(0, 0) }
+                        if iszero(slt(add(offset, 35), calldatasize())) { revert(0, 0) }
+                        let length := calldataload(add(4, offset))
+                        if gt(length, sub(shl(64, 1), 1)) { revert(0, 0) }
+                        if gt(add(add(offset, length), 36), calldatasize()) { revert(0, 0) }
+                        /// @src 23:3261:3268  "_amount"
+                        fun_transferImpl(value0_1, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ calldataload(36))
+                        return(0, 0)
+                    }
+                    case 0x70a08231 { external_fun_balances() }
+                    case 0x888b2284 {
+                        if callvalue() { revert(0, 0) }
+                        if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
+                        pop(abi_decode_address())
+                        let _2 := sload(/** @src 23:4320:4324  "true" */ 0x01)
+                        /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+                        let memPos := mload(64)
+                        mstore(memPos, /** @src 23:4320:4324  "true" */ 0x01)
+                        /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+                        mstore(add(memPos, 32), _2)
+                        return(memPos, 64)
+                    }
+                    case 0x9b19251a {
+                        if callvalue() { revert(0, 0) }
+                        if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
+                        pop(abi_decode_address())
+                        let memPos_1 := mload(64)
+                        mstore(memPos_1, 0)
+                        return(memPos_1, 32)
+                    }
+                    case 0xb52d15e2 {
+                        if callvalue() { revert(0, 0) }
+                        if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
+                        /// @src 23:2501:2523  "return admin4 == _user"
+                        let var_admin := /** @src 23:2508:2523  "admin4 == _user" */ eq(/** @src 23:1797:1803  "0x1234" */ 0x1234, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(abi_decode_address(), sub(shl(160, 1), 1)))
+                        let memPos_2 := mload(64)
+                        mstore(memPos_2, var_admin)
+                        return(memPos_2, 32)
+                    }
+                    case 0xd89d1510 {
+                        if callvalue() { revert(0, 0) }
+                        if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
+                        let ret := fun_administrators(calldataload(4))
+                        let memPos_3 := mload(64)
+                        mstore(memPos_3, and(ret, sub(shl(160, 1), 1)))
+                        return(memPos_3, 32)
+                    }
+                    case 0xea28d320 {
+                        if slt(add(calldatasize(), not(3)), 64) { revert(0, 0) }
+                        let value0_2 := abi_decode_address()
+                        let value_1 := calldataload(36)
+                        /// @src 23:4111:4140  "WhiteListTransfer(_recipient)"
+                        log2(/** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0, 0, /** @src 23:4111:4140  "WhiteListTransfer(_recipient)" */ 0x98eaee7299e9cbfa56cf530fd3a0c6dfa0ccddf4f837b8f025651ad9594647b3, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(/** @src 23:4111:4140  "WhiteListTransfer(_recipient)" */ value0_2, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ sub(shl(160, 1), 1)))
+                        sstore(1, value_1)
+                        /// @src 23:4210:4217  "_amount"
+                        fun_transferImpl(value0_2, value_1)
+                        /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+                        return(0, 0)
+                    }
+                }
+                revert(0, 0)
+            }
+            function abi_decode_address() -> value
+            {
+                value := calldataload(4)
+                if iszero(eq(value, and(value, sub(shl(160, 1), 1)))) { revert(0, 0) }
+            }
+            function external_fun_balances()
+            {
+                if callvalue() { revert(0, 0) }
+                if slt(add(calldatasize(), not(3)), 32)
+                {
+                    revert(/** @src -1:-1:-1 */ 0, 0)
+                }
+                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+                let value0 := abi_decode_address()
+                /// @src 23:2787:2806  "balancesImpl(_user)"
+                let var_balance := /** @src -1:-1:-1 */ 0
+                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+                let _1 := and(value0, sub(shl(160, 1), 1))
+                mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ _1)
+                mstore(32, /** @src -1:-1:-1 */ 0)
+                /// @src 23:2906:2936  "balance_ = the_balances[_user]"
+                var_balance := /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ sload(keccak256(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x40))
+                /// @src 23:2946:3029  "if (_user == admin4) {..."
+                if /** @src 23:2950:2965  "_user == admin4" */ eq(/** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ _1, /** @src 23:1797:1803  "0x1234" */ 0x1234)
+                /// @src 23:2946:3029  "if (_user == admin4) {..."
+                {
+                    /// @src 23:2993:3016  "balance_ += totalSupply"
+                    var_balance := /** @src 23:1841:1851  "1000000000" */ add(/** @src 23:2993:3016  "balance_ += totalSupply" */ var_balance, /** @src 23:1841:1851  "1000000000" */ 0x3b9aca00)
+                }
+                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+                let memPos := mload(0x40)
+                mstore(memPos, var_balance)
+                return(memPos, 32)
+            }
+            /// @ast-id 39272 @src 23:2144:2413  "function administrators(uint256 _index) external view returns (address admin_) {..."
+            function fun_administrators(var_index) -> var_admin
+            {
+                /// @src 23:2207:2221  "address admin_"
+                var_admin := /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0
+                /// @src 23:2233:2263  "if (_index == 0) return admin0"
+                if /** @src 23:2237:2248  "_index == 0" */ iszero(var_index)
+                /// @src 23:2233:2263  "if (_index == 0) return admin0"
+                {
+                    /// @src 23:2250:2263  "return admin0"
+                    var_admin := /** @src 23:2257:2263  "admin0" */ loadimmutable("39177")
+                    /// @src 23:2250:2263  "return admin0"
+                    leave
+                }
+                /// @src 23:2273:2303  "if (_index == 1) return admin1"
+                if /** @src 23:2277:2288  "_index == 1" */ eq(var_index, /** @src 23:2287:2288  "1" */ 0x01)
+                /// @src 23:2273:2303  "if (_index == 1) return admin1"
+                {
+                    /// @src 23:2290:2303  "return admin1"
+                    var_admin := /** @src 23:2297:2303  "admin1" */ loadimmutable("39179")
+                    /// @src 23:2290:2303  "return admin1"
+                    leave
+                }
+                /// @src 23:2313:2343  "if (_index == 2) return admin2"
+                if /** @src 23:2317:2328  "_index == 2" */ eq(var_index, /** @src 23:2327:2328  "2" */ 0x02)
+                /// @src 23:2313:2343  "if (_index == 2) return admin2"
+                {
+                    /// @src 23:2330:2343  "return admin2"
+                    var_admin := /** @src 23:2337:2343  "admin2" */ loadimmutable("39181")
+                    /// @src 23:2330:2343  "return admin2"
+                    leave
+                }
+                /// @src 23:2353:2383  "if (_index == 3) return admin3"
+                if /** @src 23:2357:2368  "_index == 3" */ eq(var_index, /** @src 23:2367:2368  "3" */ 0x03)
+                /// @src 23:2353:2383  "if (_index == 3) return admin3"
+                {
+                    /// @src 23:2370:2383  "return admin3"
+                    var_admin := /** @src 23:2377:2383  "admin3" */ loadimmutable("39183")
+                    /// @src 23:2370:2383  "return admin3"
+                    leave
+                }
+                /// @src 23:2393:2406  "return admin4"
+                var_admin := /** @src 23:1797:1803  "0x1234" */ 0x1234
+            }
+            /// @ast-id 39378 @src 23:3282:3619  "function transferImpl(..."
+            function fun_transferImpl(var_recipient, var_amount)
+            {
+                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+                mstore(/** @src 23:3516:3528  "the_balances" */ 0x00, /** @src 23:3529:3539  "msg.sender" */ caller())
+                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+                mstore(0x20, /** @src 23:3516:3528  "the_balances" */ 0x00)
+                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+                let dataSlot := keccak256(/** @src 23:3516:3528  "the_balances" */ 0x00, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x40)
+                sstore(dataSlot, sub(sload(/** @src 23:3516:3551  "the_balances[msg.sender] -= _amount" */ dataSlot), /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ var_amount))
+                mstore(/** @src 23:3516:3528  "the_balances" */ 0x00, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(var_recipient, sub(shl(160, 1), 1)))
+                mstore(0x20, /** @src 23:3516:3528  "the_balances" */ 0x00)
+                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+                let dataSlot_1 := keccak256(/** @src 23:3516:3528  "the_balances" */ 0x00, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x40)
+                sstore(dataSlot_1, /** @src 23:1841:1851  "1000000000" */ add(/** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ sload(/** @src 23:3575:3610  "the_balances[_recipient] += _amount" */ dataSlot_1), /** @src 23:1841:1851  "1000000000" */ var_amount))
+            }
+        }
+        data ".metadata" hex""
+    }
+}

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -27,6 +27,7 @@ object "GasContractYul" {
 	object "GasContractYul_deployed" {
 		code {
 			{
+				let _arg0 := calldataload(4)
 				switch shr(224, calldataload(0))
 				case 0x214405fc {
 					// addToWhitelist
@@ -39,18 +40,18 @@ object "GasContractYul" {
 						)
 					) { revert(0, 0) }
 
-					mstore(0, calldataload(4))
+					mstore(0, _arg0)
 					mstore(32, _tier)
 					log1(0, 64, 0x62c1e066774519db9fe35767c15fc33df2f016675b7cc0c330ed185f286a2d52)
 
 					stop()
 				}
-				case 0x27e235e3 { external_fun_balances() }
+				case 0x27e235e3 { external_fun_balances(_arg0) }
 				case 0x56b8c724 {
 					// transfer
-					fun_transferImpl(calldataload(4), calldataload(36))
+					fun_transferImpl(_arg0, calldataload(36))
 				}
-				case 0x70a08231 { external_fun_balances() }
+				case 0x70a08231 { external_fun_balances(_arg0) }
 				case 0x888b2284 {
 					// getPaymentStatus
 					mstore(0, 0x01)
@@ -63,12 +64,12 @@ object "GasContractYul" {
 				}
 				case 0xb52d15e2 {
 					// checkForAdmin
-					mstore(0, eq(0x1234, calldataload(4)))
+					mstore(0, eq(0x1234, _arg0))
 					return(0, 32)
 				}
 				case 0xd89d1510 {
 					// adminstrators
-					let _index := calldataload(4)
+					let _index := _arg0
 					let _offset := add(datasize("GasContractYul_deployed"), mul(20, _index))
 					codecopy(12, _offset, 20)
 					mstore(32, 0x1234)
@@ -77,7 +78,7 @@ object "GasContractYul" {
 				}
 				case 0xea28d320 {
 					// whiteTransfer
-					let _recipient := calldataload(4)
+					let _recipient := _arg0
 					let _amount := calldataload(36)
 					log2(0, 0, 0x98eaee7299e9cbfa56cf530fd3a0c6dfa0ccddf4f837b8f025651ad9594647b3, _recipient)
 					sstore(1, _amount)
@@ -86,9 +87,8 @@ object "GasContractYul" {
 				revert(0, 0)
 			}
 
-			function external_fun_balances()
+			function external_fun_balances(_user)
 			{
-				let _user := calldataload(4)
 				mstore(0, _user)
 				let var_balance := sload(keccak256(0, 0x40))
 				var_balance := add(var_balance, mul(eq(_user, 0x1234), 0x3b9aca00))

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -178,13 +178,11 @@ object "GasContractYul" {
 					}
 					case 0x70a08231 { external_fun_balances() }
 					case 0x888b2284 {
-						if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
-						pop(abi_decode_address())
+						// getPaymentStatus
+						pop(abi_decode_address())	// no gas report if this line removed
 						let _2 := sload(0x01)
-
-						let memPos := mload(64)
+						let memPos := 0x40		// no gas report if zero used here
 						mstore(memPos, 0x01)
-
 						mstore(add(memPos, 32), _2)
 						return(memPos, 64)
 					}

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -6,11 +6,21 @@ object "GasContractYul" {
 			// [64, B, A.length, A[0], A[1], A[2], A[3], ...]
 			let _offset := dataoffset("GasContractYul_deployed")
 			let _size := datasize("GasContractYul_deployed")
-			let _admins := add(add(_offset, _size), 96)
-			let _total := add(_size, 128)
+			let _args := add(_offset, _size)
 			codecopy(0, _offset, _size)
-			codecopy(_size, _admins, 128)
-			return(0, _total)
+			_args := add(_args, 108)
+			codecopy(_size, _args, 20)
+			_size := add(_size, 20)
+			_args := add(_args, 32)
+			codecopy(_size, _args, 20)
+			_size := add(_size, 20)
+			_args := add(_args, 32)
+			codecopy(_size, _args, 20)
+			_size := add(_size, 20)
+			_args := add(_args, 32)
+			codecopy(_size, _args, 20)
+			_size := add(_size, 20)
+			return(0, _size)
 		}
 	}
 
@@ -62,8 +72,8 @@ object "GasContractYul" {
 					case 0xd89d1510 {
 						// adminstrators
 						let _index := calldataload(4)
-						let _offset := add(datasize("GasContractYul_deployed"), shl(5, _index))
-						codecopy(0, _offset, 32)
+						let _offset := add(datasize("GasContractYul_deployed"), mul(20, _index))
+						codecopy(12, _offset, 20)
 						mstore(32, 0x1234)
 						let _return := shl(5, eq(_index, 4))
 						return(_return, 32)

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -29,8 +29,8 @@ object "GasContractYul" {
 			{
 				let _arg0 := calldataload(4)
 				let _arg1 := calldataload(36)
-				switch shr(224, calldataload(0))
-				case 0x214405fc {
+				switch byte(0, calldataload(0))
+				case 0x21 {
 					// addToWhitelist
 					let _tier := _arg1
 
@@ -47,28 +47,28 @@ object "GasContractYul" {
 
 					stop()
 				}
-				case 0x27e235e3 { external_fun_balances(_arg0) }
-				case 0x56b8c724 {
+				case 0x27 { external_fun_balances(_arg0) }
+				case 0x56 {
 					// transfer
 					fun_transferImpl(_arg0, _arg1)
 				}
-				case 0x70a08231 { external_fun_balances(_arg0) }
-				case 0x888b2284 {
+				case 0x70 { external_fun_balances(_arg0) }
+				case 0x88 {
 					// getPaymentStatus
 					mstore(0, 0x01)
 					mstore(32, sload(0x01))
 					return(0, 64)
 				}
-				case 0x9b19251a {
+				case 0x9b {
 					// whitelist
 					return(0, 32)
 				}
-				case 0xb52d15e2 {
+				case 0xb5 {
 					// checkForAdmin
 					mstore(0, eq(0x1234, _arg0))
 					return(0, 32)
 				}
-				case 0xd89d1510 {
+				case 0xd8 {
 					// adminstrators
 					let _index := _arg0
 					let _offset := add(datasize("GasContractYul_deployed"), mul(20, _index))
@@ -77,7 +77,7 @@ object "GasContractYul" {
 					let _return := shl(5, eq(_index, 4))
 					return(_return, 32)
 				}
-				case 0xea28d320 {
+				case 0xea {
 					// whiteTransfer
 					let _recipient := _arg0
 					let _amount := _arg1

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -28,10 +28,11 @@ object "GasContractYul" {
 		code {
 			{
 				let _arg0 := calldataload(4)
+				let _arg1 := calldataload(36)
 				switch shr(224, calldataload(0))
 				case 0x214405fc {
 					// addToWhitelist
-					let _tier := calldataload(36)
+					let _tier := _arg1
 
 					if iszero(
 						and(
@@ -49,7 +50,7 @@ object "GasContractYul" {
 				case 0x27e235e3 { external_fun_balances(_arg0) }
 				case 0x56b8c724 {
 					// transfer
-					fun_transferImpl(_arg0, calldataload(36))
+					fun_transferImpl(_arg0, _arg1)
 				}
 				case 0x70a08231 { external_fun_balances(_arg0) }
 				case 0x888b2284 {
@@ -79,7 +80,7 @@ object "GasContractYul" {
 				case 0xea28d320 {
 					// whiteTransfer
 					let _recipient := _arg0
-					let _amount := calldataload(36)
+					let _amount := _arg1
 					log2(0, 0, 0x98eaee7299e9cbfa56cf530fd3a0c6dfa0ccddf4f837b8f025651ad9594647b3, _recipient)
 					sstore(1, _amount)
 					fun_transferImpl(_recipient, _amount)

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -1,329 +1,329 @@
 
 object "GasContractYul" {
-    code {
-        {
-
-            mstore(64, memoryguard(0x0100))
-            let programSize := datasize("GasContractYul")
-            let argSize := sub(codesize(), programSize)
-            let memoryDataOffset := allocate_memory(argSize)
-            codecopy(memoryDataOffset, programSize, argSize)
-            let _1 := add(memoryDataOffset, argSize)
-            if slt(sub(_1, memoryDataOffset), 64)
-            {
-                revert(0, 0)
-            }
-
-            let offset := mload(memoryDataOffset)
-            if gt(offset, sub(shl(64, 1), 1))
-            {
-                revert(0, 0)
-            }
-
-            let _2 := add(memoryDataOffset, offset)
-            if iszero(slt(add(_2, 0x1f), _1))
-            {
-                revert(0, 0)
-            }
-
-            let length := mload(_2)
-            if gt(length, sub(shl(64, 1), 1))
-            {
-                mstore(0, shl(224, 0x4e487b71))
-                mstore(4, 0x41)
-                revert(0, 0x24)
-            }
-            let _3 := shl(5, length)
-            let dst := allocate_memory(add(_3, 0x20))
-            let array := dst
-            mstore(dst, length)
-            dst := add(dst, 0x20)
-            let dst_1 := dst
-            let srcEnd := add(add(_2, _3), 0x20)
-            if gt(srcEnd, _1)
-            {
-                revert(0, 0)
-            }
-
-            let src := add(_2, 0x20)
-            for { } lt(src, srcEnd) { src := add(src, 0x20) }
-            {
-                let value := mload(src)
-                if iszero(eq(value, and(value, sub(shl(160, 1), 1))))
-                {
-                    revert(0, 0)
-                }
-
-                mstore(dst, value)
-                dst := add(dst, 0x20)
-            }
-
-            let addr := 0
-
-            if iszero(mload(array))
-            {
-                mstore(0, shl(224, 0x4e487b71))
-                mstore(4, 0x32)
-                revert(0, 0x24)
-            }
-            addr := dst_1
-
-            mstore(128, and(mload(dst_1), sub(shl(160, 1), 1)))
-
-            let addr_1 := 0
-
-            if iszero(lt(0x01, mload(array)))
-            {
-                mstore(0, shl(224, 0x4e487b71))
-                mstore(4, 0x32)
-                revert(0, 0x24)
-            }
-            addr_1 := add(array, 64)
-
-            mstore(160, and(mload(addr_1), sub(shl(160, 1), 1)))
-
-            let addr_2 := 0
-
-            if iszero(lt(0x02, mload(array)))
-            {
-                mstore(0, shl(224, 0x4e487b71))
-                mstore(4, 0x32)
-                revert(0, 0x24)
-            }
-            addr_2 := add(array, 96)
-
-            mstore(192, and(mload(addr_2), sub(shl(160, 1), 1)))
-
-            let addr_3 := 0
-
-            if iszero(lt(0x03, mload(array)))
-            {
-                mstore(0, shl(224, 0x4e487b71))
-                mstore(4, 0x32)
-                revert(0, 0x24)
-            }
-            addr_3 := add(array, 128)
-
-            mstore(224, and(mload(addr_3), sub(shl(160, 1), 1)))
-            let _4 := mload(64)
-            let _5 := datasize("GasContractYul_deployed")
-            codecopy(_4, dataoffset("GasContractYul_deployed"), _5)
-            setimmutable(_4, "39177", mload(128))
-
-            setimmutable(_4, "39179", mload(160))
-
-            setimmutable(_4, "39181", mload(192))
-
-            setimmutable(_4, "39183", mload(224))
-
-            return(_4, _5)
-        }
-        function allocate_memory(size) -> memPtr
-        {
-            memPtr := mload(64)
-            let newFreePtr := add(memPtr, and(add(size, 31), not(31)))
-            if or(gt(newFreePtr, sub(shl(64, 1), 1)), lt(newFreePtr, memPtr))
-            {
-                mstore(0, shl(224, 0x4e487b71))
-                mstore(4, 0x41)
-                revert(0, 0x24)
-            }
-            mstore(64, newFreePtr)
-        }
-    }
-
-    object "GasContractYul_deployed" {
-        code {
-            {
-
-                let _1 := memoryguard(0x80)
-                mstore(64, _1)
-                if iszero(lt(calldatasize(), 4))
-                {
-                    switch shr(224, calldataload(0))
-                    case 0x214405fc {
-                        if slt(add(calldatasize(), not(3)), 64) { revert(0, 0) }
-                        let value0 := abi_decode_address()
-                        let value := calldataload(36)
-
-                        if iszero(eq(0x1234, caller()))
-
-                        {
-
-                            revert(0, 0)
-                        }
-                        if iszero(lt(value, 0xff))
-
-                        { revert(0, 0) }
-                        mstore(_1, and(value0, sub(shl(160, 1), 1)))
-                        mstore(add(_1, 32), value)
-
-                        log1(_1, 64, 0x62c1e066774519db9fe35767c15fc33df2f016675b7cc0c330ed185f286a2d52)
-
-                        return(0, 0)
-                    }
-                    case 0x27e235e3 { external_fun_balances() }
-                    case 0x56b8c724 {
-                        if slt(add(calldatasize(), not(3)), 96) { revert(0, 0) }
-                        let value0_1 := abi_decode_address()
-                        let offset := calldataload(68)
-                        if gt(offset, sub(shl(64, 1), 1)) { revert(0, 0) }
-                        if iszero(slt(add(offset, 35), calldatasize())) { revert(0, 0) }
-                        let length := calldataload(add(4, offset))
-                        if gt(length, sub(shl(64, 1), 1)) { revert(0, 0) }
-                        if gt(add(add(offset, length), 36), calldatasize()) { revert(0, 0) }
-
-                        fun_transferImpl(value0_1, calldataload(36))
-                        return(0, 0)
-                    }
-                    case 0x70a08231 { external_fun_balances() }
-                    case 0x888b2284 {
-                        if callvalue() { revert(0, 0) }
-                        if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
-                        pop(abi_decode_address())
-                        let _2 := sload(0x01)
-
-                        let memPos := mload(64)
-                        mstore(memPos, 0x01)
-
-                        mstore(add(memPos, 32), _2)
-                        return(memPos, 64)
-                    }
-                    case 0x9b19251a {
-                        if callvalue() { revert(0, 0) }
-                        if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
-                        pop(abi_decode_address())
-                        let memPos_1 := mload(64)
-                        mstore(memPos_1, 0)
-                        return(memPos_1, 32)
-                    }
-                    case 0xb52d15e2 {
-                        if callvalue() { revert(0, 0) }
-                        if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
-
-                        let var_admin := eq(0x1234, and(abi_decode_address(), sub(shl(160, 1), 1)))
-                        let memPos_2 := mload(64)
-                        mstore(memPos_2, var_admin)
-                        return(memPos_2, 32)
-                    }
-                    case 0xd89d1510 {
-                        if callvalue() { revert(0, 0) }
-                        if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
-                        let ret := fun_administrators(calldataload(4))
-                        let memPos_3 := mload(64)
-                        mstore(memPos_3, and(ret, sub(shl(160, 1), 1)))
-                        return(memPos_3, 32)
-                    }
-                    case 0xea28d320 {
-                        if slt(add(calldatasize(), not(3)), 64) { revert(0, 0) }
-                        let value0_2 := abi_decode_address()
-                        let value_1 := calldataload(36)
-
-                        log2(0, 0, 0x98eaee7299e9cbfa56cf530fd3a0c6dfa0ccddf4f837b8f025651ad9594647b3, and(value0_2, sub(shl(160, 1), 1)))
-                        sstore(1, value_1)
-
-                        fun_transferImpl(value0_2, value_1)
-
-                        return(0, 0)
-                    }
-                }
-                revert(0, 0)
-            }
-            function abi_decode_address() -> value
-            {
-                value := calldataload(4)
-                if iszero(eq(value, and(value, sub(shl(160, 1), 1)))) { revert(0, 0) }
-            }
-            function external_fun_balances()
-            {
-                if callvalue() { revert(0, 0) }
-                if slt(add(calldatasize(), not(3)), 32)
-                {
-                    revert(0, 0)
-                }
-
-                let value0 := abi_decode_address()
-
-                let var_balance := 0
-
-                let _1 := and(value0, sub(shl(160, 1), 1))
-                mstore(0, _1)
-                mstore(32, 0)
-
-                var_balance := sload(keccak256(0, 0x40))
-
-                if eq(_1, 0x1234)
-
-                {
-
-                    var_balance := add(var_balance, 0x3b9aca00)
-                }
-
-                let memPos := mload(0x40)
-                mstore(memPos, var_balance)
-                return(memPos, 32)
-            }
-
-            function fun_administrators(var_index) -> var_admin
-            {
-
-                var_admin := 0
-
-                if iszero(var_index)
-
-                {
-
-                    var_admin := loadimmutable("39177")
-
-                    leave
-                }
-
-                if eq(var_index, 0x01)
-
-                {
-
-                    var_admin := loadimmutable("39179")
-
-                    leave
-                }
-
-                if eq(var_index, 0x02)
-
-                {
-
-                    var_admin := loadimmutable("39181")
-
-                    leave
-                }
-
-                if eq(var_index, 0x03)
-
-                {
-
-                    var_admin := loadimmutable("39183")
-
-                    leave
-                }
-
-                var_admin := 0x1234
-            }
-
-            function fun_transferImpl(var_recipient, var_amount)
-            {
-
-                mstore(0x00, caller())
-
-                mstore(0x20, 0x00)
-
-                let dataSlot := keccak256(0x00, 0x40)
-                sstore(dataSlot, sub(sload(dataSlot), var_amount))
-                mstore(0x00, and(var_recipient, sub(shl(160, 1), 1)))
-                mstore(0x20, 0x00)
-
-                let dataSlot_1 := keccak256(0x00, 0x40)
-                sstore(dataSlot_1, add(sload(dataSlot_1), var_amount))
-            }
-        }
-        data ".metadata" hex""
-    }
+	code {
+		{
+
+			mstore(64, memoryguard(0x0100))
+			let programSize := datasize("GasContractYul")
+			let argSize := sub(codesize(), programSize)
+			let memoryDataOffset := allocate_memory(argSize)
+			codecopy(memoryDataOffset, programSize, argSize)
+			let _1 := add(memoryDataOffset, argSize)
+			if slt(sub(_1, memoryDataOffset), 64)
+			{
+				revert(0, 0)
+			}
+
+			let offset := mload(memoryDataOffset)
+			if gt(offset, sub(shl(64, 1), 1))
+			{
+				revert(0, 0)
+			}
+
+			let _2 := add(memoryDataOffset, offset)
+			if iszero(slt(add(_2, 0x1f), _1))
+			{
+				revert(0, 0)
+			}
+
+			let length := mload(_2)
+			if gt(length, sub(shl(64, 1), 1))
+			{
+				mstore(0, shl(224, 0x4e487b71))
+				mstore(4, 0x41)
+				revert(0, 0x24)
+			}
+			let _3 := shl(5, length)
+			let dst := allocate_memory(add(_3, 0x20))
+			let array := dst
+			mstore(dst, length)
+			dst := add(dst, 0x20)
+			let dst_1 := dst
+			let srcEnd := add(add(_2, _3), 0x20)
+			if gt(srcEnd, _1)
+			{
+				revert(0, 0)
+			}
+
+			let src := add(_2, 0x20)
+			for { } lt(src, srcEnd) { src := add(src, 0x20) }
+			{
+				let value := mload(src)
+				if iszero(eq(value, and(value, sub(shl(160, 1), 1))))
+				{
+					revert(0, 0)
+				}
+
+				mstore(dst, value)
+				dst := add(dst, 0x20)
+			}
+
+			let addr := 0
+
+			if iszero(mload(array))
+			{
+				mstore(0, shl(224, 0x4e487b71))
+				mstore(4, 0x32)
+				revert(0, 0x24)
+			}
+			addr := dst_1
+
+			mstore(128, and(mload(dst_1), sub(shl(160, 1), 1)))
+
+			let addr_1 := 0
+
+			if iszero(lt(0x01, mload(array)))
+			{
+				mstore(0, shl(224, 0x4e487b71))
+				mstore(4, 0x32)
+				revert(0, 0x24)
+			}
+			addr_1 := add(array, 64)
+
+			mstore(160, and(mload(addr_1), sub(shl(160, 1), 1)))
+
+			let addr_2 := 0
+
+			if iszero(lt(0x02, mload(array)))
+			{
+				mstore(0, shl(224, 0x4e487b71))
+				mstore(4, 0x32)
+				revert(0, 0x24)
+			}
+			addr_2 := add(array, 96)
+
+			mstore(192, and(mload(addr_2), sub(shl(160, 1), 1)))
+
+			let addr_3 := 0
+
+			if iszero(lt(0x03, mload(array)))
+			{
+				mstore(0, shl(224, 0x4e487b71))
+				mstore(4, 0x32)
+				revert(0, 0x24)
+			}
+			addr_3 := add(array, 128)
+
+			mstore(224, and(mload(addr_3), sub(shl(160, 1), 1)))
+			let _4 := mload(64)
+			let _5 := datasize("GasContractYul_deployed")
+			codecopy(_4, dataoffset("GasContractYul_deployed"), _5)
+			setimmutable(_4, "39177", mload(128))
+
+			setimmutable(_4, "39179", mload(160))
+
+			setimmutable(_4, "39181", mload(192))
+
+			setimmutable(_4, "39183", mload(224))
+
+			return(_4, _5)
+		}
+		function allocate_memory(size) -> memPtr
+		{
+			memPtr := mload(64)
+			let newFreePtr := add(memPtr, and(add(size, 31), not(31)))
+			if or(gt(newFreePtr, sub(shl(64, 1), 1)), lt(newFreePtr, memPtr))
+			{
+				mstore(0, shl(224, 0x4e487b71))
+				mstore(4, 0x41)
+				revert(0, 0x24)
+			}
+			mstore(64, newFreePtr)
+		}
+	}
+
+	object "GasContractYul_deployed" {
+		code {
+			{
+
+				let _1 := memoryguard(0x80)
+				mstore(64, _1)
+				if iszero(lt(calldatasize(), 4))
+				{
+					switch shr(224, calldataload(0))
+					case 0x214405fc {
+						if slt(add(calldatasize(), not(3)), 64) { revert(0, 0) }
+						let value0 := abi_decode_address()
+						let value := calldataload(36)
+
+						if iszero(eq(0x1234, caller()))
+
+						{
+
+							revert(0, 0)
+						}
+						if iszero(lt(value, 0xff))
+
+						{ revert(0, 0) }
+						mstore(_1, and(value0, sub(shl(160, 1), 1)))
+						mstore(add(_1, 32), value)
+
+						log1(_1, 64, 0x62c1e066774519db9fe35767c15fc33df2f016675b7cc0c330ed185f286a2d52)
+
+						return(0, 0)
+					}
+					case 0x27e235e3 { external_fun_balances() }
+					case 0x56b8c724 {
+						if slt(add(calldatasize(), not(3)), 96) { revert(0, 0) }
+						let value0_1 := abi_decode_address()
+						let offset := calldataload(68)
+						if gt(offset, sub(shl(64, 1), 1)) { revert(0, 0) }
+						if iszero(slt(add(offset, 35), calldatasize())) { revert(0, 0) }
+						let length := calldataload(add(4, offset))
+						if gt(length, sub(shl(64, 1), 1)) { revert(0, 0) }
+						if gt(add(add(offset, length), 36), calldatasize()) { revert(0, 0) }
+
+						fun_transferImpl(value0_1, calldataload(36))
+						return(0, 0)
+					}
+					case 0x70a08231 { external_fun_balances() }
+					case 0x888b2284 {
+						if callvalue() { revert(0, 0) }
+						if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
+						pop(abi_decode_address())
+						let _2 := sload(0x01)
+
+						let memPos := mload(64)
+						mstore(memPos, 0x01)
+
+						mstore(add(memPos, 32), _2)
+						return(memPos, 64)
+					}
+					case 0x9b19251a {
+						if callvalue() { revert(0, 0) }
+						if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
+						pop(abi_decode_address())
+						let memPos_1 := mload(64)
+						mstore(memPos_1, 0)
+						return(memPos_1, 32)
+					}
+					case 0xb52d15e2 {
+						if callvalue() { revert(0, 0) }
+						if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
+
+						let var_admin := eq(0x1234, and(abi_decode_address(), sub(shl(160, 1), 1)))
+						let memPos_2 := mload(64)
+						mstore(memPos_2, var_admin)
+						return(memPos_2, 32)
+					}
+					case 0xd89d1510 {
+						if callvalue() { revert(0, 0) }
+						if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
+						let ret := fun_administrators(calldataload(4))
+						let memPos_3 := mload(64)
+						mstore(memPos_3, and(ret, sub(shl(160, 1), 1)))
+						return(memPos_3, 32)
+					}
+					case 0xea28d320 {
+						if slt(add(calldatasize(), not(3)), 64) { revert(0, 0) }
+						let value0_2 := abi_decode_address()
+						let value_1 := calldataload(36)
+
+						log2(0, 0, 0x98eaee7299e9cbfa56cf530fd3a0c6dfa0ccddf4f837b8f025651ad9594647b3, and(value0_2, sub(shl(160, 1), 1)))
+						sstore(1, value_1)
+
+						fun_transferImpl(value0_2, value_1)
+
+						return(0, 0)
+					}
+				}
+				revert(0, 0)
+			}
+			function abi_decode_address() -> value
+			{
+				value := calldataload(4)
+				if iszero(eq(value, and(value, sub(shl(160, 1), 1)))) { revert(0, 0) }
+			}
+			function external_fun_balances()
+			{
+				if callvalue() { revert(0, 0) }
+				if slt(add(calldatasize(), not(3)), 32)
+				{
+					revert(0, 0)
+				}
+
+				let value0 := abi_decode_address()
+
+				let var_balance := 0
+
+				let _1 := and(value0, sub(shl(160, 1), 1))
+				mstore(0, _1)
+				mstore(32, 0)
+
+				var_balance := sload(keccak256(0, 0x40))
+
+				if eq(_1, 0x1234)
+
+				{
+
+					var_balance := add(var_balance, 0x3b9aca00)
+				}
+
+				let memPos := mload(0x40)
+				mstore(memPos, var_balance)
+				return(memPos, 32)
+			}
+
+			function fun_administrators(var_index) -> var_admin
+			{
+
+				var_admin := 0
+
+				if iszero(var_index)
+
+				{
+
+					var_admin := loadimmutable("39177")
+
+					leave
+				}
+
+				if eq(var_index, 0x01)
+
+				{
+
+					var_admin := loadimmutable("39179")
+
+					leave
+				}
+
+				if eq(var_index, 0x02)
+
+				{
+
+					var_admin := loadimmutable("39181")
+
+					leave
+				}
+
+				if eq(var_index, 0x03)
+
+				{
+
+					var_admin := loadimmutable("39183")
+
+					leave
+				}
+
+				var_admin := 0x1234
+			}
+
+			function fun_transferImpl(var_recipient, var_amount)
+			{
+
+				mstore(0x00, caller())
+
+				mstore(0x20, 0x00)
+
+				let dataSlot := keccak256(0x00, 0x40)
+				sstore(dataSlot, sub(sload(dataSlot), var_amount))
+				mstore(0x00, and(var_recipient, sub(shl(160, 1), 1)))
+				mstore(0x20, 0x00)
+
+				let dataSlot_1 := keccak256(0x00, 0x40)
+				sstore(dataSlot_1, add(sload(dataSlot_1), var_amount))
+			}
+		}
+		data ".metadata" hex""
+	}
 }

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -27,64 +27,61 @@ object "GasContractYul" {
 	object "GasContractYul_deployed" {
 		code {
 			{
-				if iszero(lt(calldatasize(), 4))
-				{
-					switch shr(224, calldataload(0))
-					case 0x214405fc {
-						// addToWhitelist
-						let _tier := calldataload(36)
+				switch shr(224, calldataload(0))
+				case 0x214405fc {
+					// addToWhitelist
+					let _tier := calldataload(36)
 
-						if iszero(
-							and(
-								eq(0x1234, caller()),
-								lt(_tier, 255)
-							)
-						) { revert(0, 0) }
+					if iszero(
+						and(
+							eq(0x1234, caller()),
+							lt(_tier, 255)
+						)
+					) { revert(0, 0) }
 
-						mstore(0, calldataload(4))
-						mstore(32, _tier)
-						log1(0, 64, 0x62c1e066774519db9fe35767c15fc33df2f016675b7cc0c330ed185f286a2d52)
+					mstore(0, calldataload(4))
+					mstore(32, _tier)
+					log1(0, 64, 0x62c1e066774519db9fe35767c15fc33df2f016675b7cc0c330ed185f286a2d52)
 
-						stop()
-					}
-					case 0x27e235e3 { external_fun_balances() }
-					case 0x56b8c724 {
-						// transfer
-						fun_transferImpl(calldataload(4), calldataload(36))
-					}
-					case 0x70a08231 { external_fun_balances() }
-					case 0x888b2284 {
-						// getPaymentStatus
-						mstore(0, 0x01)
-						mstore(32, sload(0x01))
-						return(0, 64)
-					}
-					case 0x9b19251a {
-						// whitelist
-						return(0, 32)
-					}
-					case 0xb52d15e2 {
-						// checkForAdmin
-						mstore(0, eq(0x1234, calldataload(4)))
-						return(0, 32)
-					}
-					case 0xd89d1510 {
-						// adminstrators
-						let _index := calldataload(4)
-						let _offset := add(datasize("GasContractYul_deployed"), mul(20, _index))
-						codecopy(12, _offset, 20)
-						mstore(32, 0x1234)
-						let _return := shl(5, eq(_index, 4))
-						return(_return, 32)
-					}
-					case 0xea28d320 {
-						// whiteTransfer
-						let _recipient := calldataload(4)
-						let _amount := calldataload(36)
-						log2(0, 0, 0x98eaee7299e9cbfa56cf530fd3a0c6dfa0ccddf4f837b8f025651ad9594647b3, _recipient)
-						sstore(1, _amount)
-						fun_transferImpl(_recipient, _amount)
-					}
+					stop()
+				}
+				case 0x27e235e3 { external_fun_balances() }
+				case 0x56b8c724 {
+					// transfer
+					fun_transferImpl(calldataload(4), calldataload(36))
+				}
+				case 0x70a08231 { external_fun_balances() }
+				case 0x888b2284 {
+					// getPaymentStatus
+					mstore(0, 0x01)
+					mstore(32, sload(0x01))
+					return(0, 64)
+				}
+				case 0x9b19251a {
+					// whitelist
+					return(0, 32)
+				}
+				case 0xb52d15e2 {
+					// checkForAdmin
+					mstore(0, eq(0x1234, calldataload(4)))
+					return(0, 32)
+				}
+				case 0xd89d1510 {
+					// adminstrators
+					let _index := calldataload(4)
+					let _offset := add(datasize("GasContractYul_deployed"), mul(20, _index))
+					codecopy(12, _offset, 20)
+					mstore(32, 0x1234)
+					let _return := shl(5, eq(_index, 4))
+					return(_return, 32)
+				}
+				case 0xea28d320 {
+					// whiteTransfer
+					let _recipient := calldataload(4)
+					let _amount := calldataload(36)
+					log2(0, 0, 0x98eaee7299e9cbfa56cf530fd3a0c6dfa0ccddf4f837b8f025651ad9594647b3, _recipient)
+					sstore(1, _amount)
+					fun_transferImpl(_recipient, _amount)
 				}
 				revert(0, 0)
 			}

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -34,11 +34,9 @@ object "GasContractYul" {
 					// addToWhitelist
 					let _tier := _arg1
 
-					if iszero(
-						and(
-							eq(0x1234, caller()),
-							lt(_tier, 255)
-						)
+					if or(
+						sub(0x1234, caller()),
+						gt(_tier, 254)
 					) { revert(0, 0) }
 
 					mstore(0, _arg0)

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -2,37 +2,17 @@
 object "GasContractYul" {
 	code {
 		{
-
 			mstore(64, memoryguard(0x0100))
 			let programSize := datasize("GasContractYul")
 			let argSize := sub(codesize(), programSize)
 			let memoryDataOffset := allocate_memory(argSize)
 			codecopy(memoryDataOffset, programSize, argSize)
-			let _1 := add(memoryDataOffset, argSize)
-			if slt(sub(_1, memoryDataOffset), 64)
-			{
-				revert(0, 0)
-			}
 
 			let offset := mload(memoryDataOffset)
-			if gt(offset, sub(shl(64, 1), 1))
-			{
-				revert(0, 0)
-			}
 
 			let _2 := add(memoryDataOffset, offset)
-			if iszero(slt(add(_2, 0x1f), _1))
-			{
-				revert(0, 0)
-			}
 
 			let length := mload(_2)
-			if gt(length, sub(shl(64, 1), 1))
-			{
-				mstore(0, shl(224, 0x4e487b71))
-				mstore(4, 0x41)
-				revert(0, 0x24)
-			}
 			let _3 := shl(5, length)
 			let dst := allocate_memory(add(_3, 0x20))
 			let array := dst
@@ -40,80 +20,36 @@ object "GasContractYul" {
 			dst := add(dst, 0x20)
 			let dst_1 := dst
 			let srcEnd := add(add(_2, _3), 0x20)
-			if gt(srcEnd, _1)
-			{
-				revert(0, 0)
-			}
 
 			let src := add(_2, 0x20)
 			for { } lt(src, srcEnd) { src := add(src, 0x20) }
 			{
 				let value := mload(src)
-				if iszero(eq(value, and(value, sub(shl(160, 1), 1))))
-				{
-					revert(0, 0)
-				}
-
 				mstore(dst, value)
 				dst := add(dst, 0x20)
 			}
 
 			let addr := 0
-
-			if iszero(mload(array))
-			{
-				mstore(0, shl(224, 0x4e487b71))
-				mstore(4, 0x32)
-				revert(0, 0x24)
-			}
 			addr := dst_1
-
 			mstore(128, and(mload(dst_1), sub(shl(160, 1), 1)))
 
 			let addr_1 := 0
-
-			if iszero(lt(0x01, mload(array)))
-			{
-				mstore(0, shl(224, 0x4e487b71))
-				mstore(4, 0x32)
-				revert(0, 0x24)
-			}
 			addr_1 := add(array, 64)
-
 			mstore(160, and(mload(addr_1), sub(shl(160, 1), 1)))
 
 			let addr_2 := 0
-
-			if iszero(lt(0x02, mload(array)))
-			{
-				mstore(0, shl(224, 0x4e487b71))
-				mstore(4, 0x32)
-				revert(0, 0x24)
-			}
 			addr_2 := add(array, 96)
-
 			mstore(192, and(mload(addr_2), sub(shl(160, 1), 1)))
 
 			let addr_3 := 0
-
-			if iszero(lt(0x03, mload(array)))
-			{
-				mstore(0, shl(224, 0x4e487b71))
-				mstore(4, 0x32)
-				revert(0, 0x24)
-			}
 			addr_3 := add(array, 128)
-
 			mstore(224, and(mload(addr_3), sub(shl(160, 1), 1)))
 			let _4 := mload(64)
 			let _5 := datasize("GasContractYul_deployed")
 			codecopy(_4, dataoffset("GasContractYul_deployed"), _5)
 			setimmutable(_4, "39177", mload(128))
-
 			setimmutable(_4, "39179", mload(160))
-
 			setimmutable(_4, "39181", mload(192))
-
 			setimmutable(_4, "39183", mload(224))
 
 			return(_4, _5)

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -51,7 +51,6 @@ object "GasContractYul" {
 					case 0x56b8c724 {
 						// transfer
 						fun_transferImpl(calldataload(4), calldataload(36))
-						return(0, 0)
 					}
 					case 0x70a08231 { external_fun_balances() }
 					case 0x888b2284 {
@@ -85,7 +84,6 @@ object "GasContractYul" {
 						log2(0, 0, 0x98eaee7299e9cbfa56cf530fd3a0c6dfa0ccddf4f837b8f025651ad9594647b3, _recipient)
 						sstore(1, _amount)
 						fun_transferImpl(_recipient, _amount)
-						return(0, 0)
 					}
 				}
 				revert(0, 0)
@@ -109,6 +107,7 @@ object "GasContractYul" {
 				mstore(0x00, var_recipient)
 				let dataSlot_1 := keccak256(0x00, 0x40)
 				sstore(dataSlot_1, add(sload(dataSlot_1), var_amount))
+				return(0, 0)
 			}
 		}
 	}

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -1,8 +1,8 @@
-/// @use-src 23:"src/Gas.sol"
+
 object "GasContractYul" {
     code {
         {
-            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
             mstore(64, memoryguard(0x0100))
             let programSize := datasize("GasContractYul")
             let argSize := sub(codesize(), programSize)
@@ -13,19 +13,19 @@ object "GasContractYul" {
             {
                 revert(/** @src -1:-1:-1 */ 0, 0)
             }
-            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
             let offset := mload(memoryDataOffset)
             if gt(offset, sub(shl(64, 1), 1))
             {
                 revert(/** @src -1:-1:-1 */ 0, 0)
             }
-            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
             let _2 := add(memoryDataOffset, offset)
             if iszero(slt(add(_2, 0x1f), _1))
             {
                 revert(/** @src -1:-1:-1 */ 0, 0)
             }
-            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
             let length := mload(_2)
             if gt(length, sub(shl(64, 1), 1))
             {
@@ -44,7 +44,7 @@ object "GasContractYul" {
             {
                 revert(/** @src -1:-1:-1 */ 0, 0)
             }
-            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
             let src := add(_2, 0x20)
             for { } lt(src, srcEnd) { src := add(src, 0x20) }
             {
@@ -53,13 +53,13 @@ object "GasContractYul" {
                 {
                     revert(/** @src -1:-1:-1 */ 0, 0)
                 }
-                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
                 mstore(dst, value)
                 dst := add(dst, 0x20)
             }
-            /// @src 23:2034:2044  "_admins[0]"
+
             let addr := /** @src -1:-1:-1 */ 0
-            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
             if iszero(mload(array))
             {
                 mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
@@ -67,11 +67,11 @@ object "GasContractYul" {
                 revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
             }
             addr := dst_1
-            /// @src 23:2025:2044  "admin0 = _admins[0]"
+
             mstore(128, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(mload(dst_1), sub(shl(160, 1), 1)))
-            /// @src 23:2063:2073  "_admins[1]"
+
             let addr_1 := /** @src -1:-1:-1 */ 0
-            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
             if iszero(lt(/** @src 23:2071:2072  "1" */ 0x01, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ mload(array)))
             {
                 mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
@@ -79,11 +79,11 @@ object "GasContractYul" {
                 revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
             }
             addr_1 := add(array, 64)
-            /// @src 23:2054:2073  "admin1 = _admins[1]"
+
             mstore(160, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(mload(addr_1), sub(shl(160, 1), 1)))
-            /// @src 23:2092:2102  "_admins[2]"
+
             let addr_2 := /** @src -1:-1:-1 */ 0
-            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
             if iszero(lt(/** @src 23:2100:2101  "2" */ 0x02, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ mload(array)))
             {
                 mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
@@ -91,11 +91,11 @@ object "GasContractYul" {
                 revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
             }
             addr_2 := add(array, 96)
-            /// @src 23:2083:2102  "admin2 = _admins[2]"
+
             mstore(192, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(mload(addr_2), sub(shl(160, 1), 1)))
-            /// @src 23:2121:2131  "_admins[3]"
+
             let addr_3 := /** @src -1:-1:-1 */ 0
-            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
             if iszero(lt(/** @src 23:2129:2130  "3" */ 0x03, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ mload(array)))
             {
                 mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
@@ -103,19 +103,19 @@ object "GasContractYul" {
                 revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
             }
             addr_3 := add(array, /** @src 23:2025:2044  "admin0 = _admins[0]" */ 128)
-            /// @src 23:2112:2131  "admin3 = _admins[3]"
+
             mstore(224, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(mload(addr_3), sub(shl(160, 1), 1)))
             let _4 := mload(64)
             let _5 := datasize("GasContractYul_deployed")
             codecopy(_4, dataoffset("GasContractYul_deployed"), _5)
             setimmutable(_4, "39177", mload(/** @src 23:2025:2044  "admin0 = _admins[0]" */ 128))
-            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
             setimmutable(_4, "39179", mload(/** @src 23:2054:2073  "admin1 = _admins[1]" */ 160))
-            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
             setimmutable(_4, "39181", mload(/** @src 23:2083:2102  "admin2 = _admins[2]" */ 192))
-            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
             setimmutable(_4, "39183", mload(/** @src 23:2112:2131  "admin3 = _admins[3]" */ 224))
-            /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
             return(_4, _5)
         }
         function allocate_memory(size) -> memPtr
@@ -131,11 +131,11 @@ object "GasContractYul" {
             mstore(64, newFreePtr)
         }
     }
-    /// @use-src 23:"src/Gas.sol"
+
     object "GasContractYul_deployed" {
         code {
             {
-                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
                 let _1 := memoryguard(0x80)
                 mstore(64, _1)
                 if iszero(lt(calldatasize(), 4))
@@ -145,21 +145,21 @@ object "GasContractYul" {
                         if slt(add(calldatasize(), not(3)), 64) { revert(0, 0) }
                         let value0 := abi_decode_address()
                         let value := calldataload(36)
-                        /// @src 23:1896:1936  "if (!checkForAdmin(msg.sender)) revert()"
+
                         if /** @src 23:1900:1926  "!checkForAdmin(msg.sender)" */ iszero(/** @src 23:2508:2523  "admin4 == _user" */ eq(/** @src 23:1797:1803  "0x1234" */ 0x1234, /** @src 23:1915:1925  "msg.sender" */ caller()))
-                        /// @src 23:1896:1936  "if (!checkForAdmin(msg.sender)) revert()"
+
                         {
-                            /// @src 23:1928:1936  "revert()"
+
                             revert(/** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0, 0)
                         }
                         if iszero(/** @src 23:3754:3765  "_tier < 255" */ lt(value, /** @src 23:3762:3765  "255" */ 0xff))
-                        /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
                         { revert(0, 0) }
                         mstore(_1, and(value0, sub(shl(160, 1), 1)))
                         mstore(add(_1, 32), value)
-                        /// @src 23:3870:3905  "AddedToWhitelist(_userAddrs, _tier)"
+
                         log1(_1, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 64, /** @src 23:3870:3905  "AddedToWhitelist(_userAddrs, _tier)" */ 0x62c1e066774519db9fe35767c15fc33df2f016675b7cc0c330ed185f286a2d52)
-                        /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
                         return(0, 0)
                     }
                     case 0x27e235e3 { external_fun_balances() }
@@ -172,7 +172,7 @@ object "GasContractYul" {
                         let length := calldataload(add(4, offset))
                         if gt(length, sub(shl(64, 1), 1)) { revert(0, 0) }
                         if gt(add(add(offset, length), 36), calldatasize()) { revert(0, 0) }
-                        /// @src 23:3261:3268  "_amount"
+
                         fun_transferImpl(value0_1, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ calldataload(36))
                         return(0, 0)
                     }
@@ -182,10 +182,10 @@ object "GasContractYul" {
                         if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
                         pop(abi_decode_address())
                         let _2 := sload(/** @src 23:4320:4324  "true" */ 0x01)
-                        /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
                         let memPos := mload(64)
                         mstore(memPos, /** @src 23:4320:4324  "true" */ 0x01)
-                        /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
                         mstore(add(memPos, 32), _2)
                         return(memPos, 64)
                     }
@@ -200,7 +200,7 @@ object "GasContractYul" {
                     case 0xb52d15e2 {
                         if callvalue() { revert(0, 0) }
                         if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
-                        /// @src 23:2501:2523  "return admin4 == _user"
+
                         let var_admin := /** @src 23:2508:2523  "admin4 == _user" */ eq(/** @src 23:1797:1803  "0x1234" */ 0x1234, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(abi_decode_address(), sub(shl(160, 1), 1)))
                         let memPos_2 := mload(64)
                         mstore(memPos_2, var_admin)
@@ -218,12 +218,12 @@ object "GasContractYul" {
                         if slt(add(calldatasize(), not(3)), 64) { revert(0, 0) }
                         let value0_2 := abi_decode_address()
                         let value_1 := calldataload(36)
-                        /// @src 23:4111:4140  "WhiteListTransfer(_recipient)"
+
                         log2(/** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0, 0, /** @src 23:4111:4140  "WhiteListTransfer(_recipient)" */ 0x98eaee7299e9cbfa56cf530fd3a0c6dfa0ccddf4f837b8f025651ad9594647b3, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(/** @src 23:4111:4140  "WhiteListTransfer(_recipient)" */ value0_2, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ sub(shl(160, 1), 1)))
                         sstore(1, value_1)
-                        /// @src 23:4210:4217  "_amount"
+
                         fun_transferImpl(value0_2, value_1)
-                        /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
                         return(0, 0)
                     }
                 }
@@ -241,85 +241,85 @@ object "GasContractYul" {
                 {
                     revert(/** @src -1:-1:-1 */ 0, 0)
                 }
-                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
                 let value0 := abi_decode_address()
-                /// @src 23:2787:2806  "balancesImpl(_user)"
+
                 let var_balance := /** @src -1:-1:-1 */ 0
-                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
                 let _1 := and(value0, sub(shl(160, 1), 1))
                 mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ _1)
                 mstore(32, /** @src -1:-1:-1 */ 0)
-                /// @src 23:2906:2936  "balance_ = the_balances[_user]"
+
                 var_balance := /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ sload(keccak256(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x40))
-                /// @src 23:2946:3029  "if (_user == admin4) {..."
+
                 if /** @src 23:2950:2965  "_user == admin4" */ eq(/** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ _1, /** @src 23:1797:1803  "0x1234" */ 0x1234)
-                /// @src 23:2946:3029  "if (_user == admin4) {..."
+
                 {
-                    /// @src 23:2993:3016  "balance_ += totalSupply"
+
                     var_balance := /** @src 23:1841:1851  "1000000000" */ add(/** @src 23:2993:3016  "balance_ += totalSupply" */ var_balance, /** @src 23:1841:1851  "1000000000" */ 0x3b9aca00)
                 }
-                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
                 let memPos := mload(0x40)
                 mstore(memPos, var_balance)
                 return(memPos, 32)
             }
-            /// @ast-id 39272 @src 23:2144:2413  "function administrators(uint256 _index) external view returns (address admin_) {..."
+
             function fun_administrators(var_index) -> var_admin
             {
-                /// @src 23:2207:2221  "address admin_"
+
                 var_admin := /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0
-                /// @src 23:2233:2263  "if (_index == 0) return admin0"
+
                 if /** @src 23:2237:2248  "_index == 0" */ iszero(var_index)
-                /// @src 23:2233:2263  "if (_index == 0) return admin0"
+
                 {
-                    /// @src 23:2250:2263  "return admin0"
+
                     var_admin := /** @src 23:2257:2263  "admin0" */ loadimmutable("39177")
-                    /// @src 23:2250:2263  "return admin0"
+
                     leave
                 }
-                /// @src 23:2273:2303  "if (_index == 1) return admin1"
+
                 if /** @src 23:2277:2288  "_index == 1" */ eq(var_index, /** @src 23:2287:2288  "1" */ 0x01)
-                /// @src 23:2273:2303  "if (_index == 1) return admin1"
+
                 {
-                    /// @src 23:2290:2303  "return admin1"
+
                     var_admin := /** @src 23:2297:2303  "admin1" */ loadimmutable("39179")
-                    /// @src 23:2290:2303  "return admin1"
+
                     leave
                 }
-                /// @src 23:2313:2343  "if (_index == 2) return admin2"
+
                 if /** @src 23:2317:2328  "_index == 2" */ eq(var_index, /** @src 23:2327:2328  "2" */ 0x02)
-                /// @src 23:2313:2343  "if (_index == 2) return admin2"
+
                 {
-                    /// @src 23:2330:2343  "return admin2"
+
                     var_admin := /** @src 23:2337:2343  "admin2" */ loadimmutable("39181")
-                    /// @src 23:2330:2343  "return admin2"
+
                     leave
                 }
-                /// @src 23:2353:2383  "if (_index == 3) return admin3"
+
                 if /** @src 23:2357:2368  "_index == 3" */ eq(var_index, /** @src 23:2367:2368  "3" */ 0x03)
-                /// @src 23:2353:2383  "if (_index == 3) return admin3"
+
                 {
-                    /// @src 23:2370:2383  "return admin3"
+
                     var_admin := /** @src 23:2377:2383  "admin3" */ loadimmutable("39183")
-                    /// @src 23:2370:2383  "return admin3"
+
                     leave
                 }
-                /// @src 23:2393:2406  "return admin4"
+
                 var_admin := /** @src 23:1797:1803  "0x1234" */ 0x1234
             }
-            /// @ast-id 39378 @src 23:3282:3619  "function transferImpl(..."
+
             function fun_transferImpl(var_recipient, var_amount)
             {
-                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
                 mstore(/** @src 23:3516:3528  "the_balances" */ 0x00, /** @src 23:3529:3539  "msg.sender" */ caller())
-                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
                 mstore(0x20, /** @src 23:3516:3528  "the_balances" */ 0x00)
-                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
                 let dataSlot := keccak256(/** @src 23:3516:3528  "the_balances" */ 0x00, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x40)
                 sstore(dataSlot, sub(sload(/** @src 23:3516:3551  "the_balances[msg.sender] -= _amount" */ dataSlot), /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ var_amount))
                 mstore(/** @src 23:3516:3528  "the_balances" */ 0x00, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(var_recipient, sub(shl(160, 1), 1)))
                 mstore(0x20, /** @src 23:3516:3528  "the_balances" */ 0x00)
-                /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
+
                 let dataSlot_1 := keccak256(/** @src 23:3516:3528  "the_balances" */ 0x00, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x40)
                 sstore(dataSlot_1, /** @src 23:1841:1851  "1000000000" */ add(/** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ sload(/** @src 23:3575:3610  "the_balances[_recipient] += _amount" */ dataSlot_1), /** @src 23:1841:1851  "1000000000" */ var_amount))
             }

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -45,7 +45,7 @@ object "GasContractYul" {
 						mstore(32, _tier)
 						log1(0, 64, 0x62c1e066774519db9fe35767c15fc33df2f016675b7cc0c330ed185f286a2d52)
 
-						return(0, 0)
+						stop()
 					}
 					case 0x27e235e3 { external_fun_balances() }
 					case 0x56b8c724 {
@@ -107,7 +107,7 @@ object "GasContractYul" {
 				mstore(0x00, var_recipient)
 				let dataSlot_1 := keccak256(0x00, 0x40)
 				sstore(dataSlot_1, add(sload(dataSlot_1), var_amount))
-				return(0, 0)
+				stop()
 			}
 		}
 	}

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -11,27 +11,27 @@ object "GasContractYul" {
             let _1 := add(memoryDataOffset, argSize)
             if slt(sub(_1, memoryDataOffset), 64)
             {
-                revert(/** @src -1:-1:-1 */ 0, 0)
+                revert(0, 0)
             }
 
             let offset := mload(memoryDataOffset)
             if gt(offset, sub(shl(64, 1), 1))
             {
-                revert(/** @src -1:-1:-1 */ 0, 0)
+                revert(0, 0)
             }
 
             let _2 := add(memoryDataOffset, offset)
             if iszero(slt(add(_2, 0x1f), _1))
             {
-                revert(/** @src -1:-1:-1 */ 0, 0)
+                revert(0, 0)
             }
 
             let length := mload(_2)
             if gt(length, sub(shl(64, 1), 1))
             {
-                mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
+                mstore(0, shl(224, 0x4e487b71))
                 mstore(4, 0x41)
-                revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
+                revert(0, 0x24)
             }
             let _3 := shl(5, length)
             let dst := allocate_memory(add(_3, 0x20))
@@ -42,7 +42,7 @@ object "GasContractYul" {
             let srcEnd := add(add(_2, _3), 0x20)
             if gt(srcEnd, _1)
             {
-                revert(/** @src -1:-1:-1 */ 0, 0)
+                revert(0, 0)
             }
 
             let src := add(_2, 0x20)
@@ -51,70 +51,70 @@ object "GasContractYul" {
                 let value := mload(src)
                 if iszero(eq(value, and(value, sub(shl(160, 1), 1))))
                 {
-                    revert(/** @src -1:-1:-1 */ 0, 0)
+                    revert(0, 0)
                 }
 
                 mstore(dst, value)
                 dst := add(dst, 0x20)
             }
 
-            let addr := /** @src -1:-1:-1 */ 0
+            let addr := 0
 
             if iszero(mload(array))
             {
-                mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
+                mstore(0, shl(224, 0x4e487b71))
                 mstore(4, 0x32)
-                revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
+                revert(0, 0x24)
             }
             addr := dst_1
 
-            mstore(128, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(mload(dst_1), sub(shl(160, 1), 1)))
+            mstore(128, and(mload(dst_1), sub(shl(160, 1), 1)))
 
-            let addr_1 := /** @src -1:-1:-1 */ 0
+            let addr_1 := 0
 
-            if iszero(lt(/** @src 23:2071:2072  "1" */ 0x01, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ mload(array)))
+            if iszero(lt(0x01, mload(array)))
             {
-                mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
+                mstore(0, shl(224, 0x4e487b71))
                 mstore(4, 0x32)
-                revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
+                revert(0, 0x24)
             }
             addr_1 := add(array, 64)
 
-            mstore(160, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(mload(addr_1), sub(shl(160, 1), 1)))
+            mstore(160, and(mload(addr_1), sub(shl(160, 1), 1)))
 
-            let addr_2 := /** @src -1:-1:-1 */ 0
+            let addr_2 := 0
 
-            if iszero(lt(/** @src 23:2100:2101  "2" */ 0x02, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ mload(array)))
+            if iszero(lt(0x02, mload(array)))
             {
-                mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
+                mstore(0, shl(224, 0x4e487b71))
                 mstore(4, 0x32)
-                revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
+                revert(0, 0x24)
             }
             addr_2 := add(array, 96)
 
-            mstore(192, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(mload(addr_2), sub(shl(160, 1), 1)))
+            mstore(192, and(mload(addr_2), sub(shl(160, 1), 1)))
 
-            let addr_3 := /** @src -1:-1:-1 */ 0
+            let addr_3 := 0
 
-            if iszero(lt(/** @src 23:2129:2130  "3" */ 0x03, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ mload(array)))
+            if iszero(lt(0x03, mload(array)))
             {
-                mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
+                mstore(0, shl(224, 0x4e487b71))
                 mstore(4, 0x32)
-                revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
+                revert(0, 0x24)
             }
-            addr_3 := add(array, /** @src 23:2025:2044  "admin0 = _admins[0]" */ 128)
+            addr_3 := add(array, 128)
 
-            mstore(224, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(mload(addr_3), sub(shl(160, 1), 1)))
+            mstore(224, and(mload(addr_3), sub(shl(160, 1), 1)))
             let _4 := mload(64)
             let _5 := datasize("GasContractYul_deployed")
             codecopy(_4, dataoffset("GasContractYul_deployed"), _5)
-            setimmutable(_4, "39177", mload(/** @src 23:2025:2044  "admin0 = _admins[0]" */ 128))
+            setimmutable(_4, "39177", mload(128))
 
-            setimmutable(_4, "39179", mload(/** @src 23:2054:2073  "admin1 = _admins[1]" */ 160))
+            setimmutable(_4, "39179", mload(160))
 
-            setimmutable(_4, "39181", mload(/** @src 23:2083:2102  "admin2 = _admins[2]" */ 192))
+            setimmutable(_4, "39181", mload(192))
 
-            setimmutable(_4, "39183", mload(/** @src 23:2112:2131  "admin3 = _admins[3]" */ 224))
+            setimmutable(_4, "39183", mload(224))
 
             return(_4, _5)
         }
@@ -124,9 +124,9 @@ object "GasContractYul" {
             let newFreePtr := add(memPtr, and(add(size, 31), not(31)))
             if or(gt(newFreePtr, sub(shl(64, 1), 1)), lt(newFreePtr, memPtr))
             {
-                mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ shl(224, 0x4e487b71))
+                mstore(0, shl(224, 0x4e487b71))
                 mstore(4, 0x41)
-                revert(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x24)
+                revert(0, 0x24)
             }
             mstore(64, newFreePtr)
         }
@@ -146,19 +146,19 @@ object "GasContractYul" {
                         let value0 := abi_decode_address()
                         let value := calldataload(36)
 
-                        if /** @src 23:1900:1926  "!checkForAdmin(msg.sender)" */ iszero(/** @src 23:2508:2523  "admin4 == _user" */ eq(/** @src 23:1797:1803  "0x1234" */ 0x1234, /** @src 23:1915:1925  "msg.sender" */ caller()))
+                        if iszero(eq(0x1234, caller()))
 
                         {
 
-                            revert(/** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0, 0)
+                            revert(0, 0)
                         }
-                        if iszero(/** @src 23:3754:3765  "_tier < 255" */ lt(value, /** @src 23:3762:3765  "255" */ 0xff))
+                        if iszero(lt(value, 0xff))
 
                         { revert(0, 0) }
                         mstore(_1, and(value0, sub(shl(160, 1), 1)))
                         mstore(add(_1, 32), value)
 
-                        log1(_1, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 64, /** @src 23:3870:3905  "AddedToWhitelist(_userAddrs, _tier)" */ 0x62c1e066774519db9fe35767c15fc33df2f016675b7cc0c330ed185f286a2d52)
+                        log1(_1, 64, 0x62c1e066774519db9fe35767c15fc33df2f016675b7cc0c330ed185f286a2d52)
 
                         return(0, 0)
                     }
@@ -173,7 +173,7 @@ object "GasContractYul" {
                         if gt(length, sub(shl(64, 1), 1)) { revert(0, 0) }
                         if gt(add(add(offset, length), 36), calldatasize()) { revert(0, 0) }
 
-                        fun_transferImpl(value0_1, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ calldataload(36))
+                        fun_transferImpl(value0_1, calldataload(36))
                         return(0, 0)
                     }
                     case 0x70a08231 { external_fun_balances() }
@@ -181,10 +181,10 @@ object "GasContractYul" {
                         if callvalue() { revert(0, 0) }
                         if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
                         pop(abi_decode_address())
-                        let _2 := sload(/** @src 23:4320:4324  "true" */ 0x01)
+                        let _2 := sload(0x01)
 
                         let memPos := mload(64)
-                        mstore(memPos, /** @src 23:4320:4324  "true" */ 0x01)
+                        mstore(memPos, 0x01)
 
                         mstore(add(memPos, 32), _2)
                         return(memPos, 64)
@@ -201,7 +201,7 @@ object "GasContractYul" {
                         if callvalue() { revert(0, 0) }
                         if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
 
-                        let var_admin := /** @src 23:2508:2523  "admin4 == _user" */ eq(/** @src 23:1797:1803  "0x1234" */ 0x1234, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(abi_decode_address(), sub(shl(160, 1), 1)))
+                        let var_admin := eq(0x1234, and(abi_decode_address(), sub(shl(160, 1), 1)))
                         let memPos_2 := mload(64)
                         mstore(memPos_2, var_admin)
                         return(memPos_2, 32)
@@ -219,7 +219,7 @@ object "GasContractYul" {
                         let value0_2 := abi_decode_address()
                         let value_1 := calldataload(36)
 
-                        log2(/** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0, 0, /** @src 23:4111:4140  "WhiteListTransfer(_recipient)" */ 0x98eaee7299e9cbfa56cf530fd3a0c6dfa0ccddf4f837b8f025651ad9594647b3, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(/** @src 23:4111:4140  "WhiteListTransfer(_recipient)" */ value0_2, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ sub(shl(160, 1), 1)))
+                        log2(0, 0, 0x98eaee7299e9cbfa56cf530fd3a0c6dfa0ccddf4f837b8f025651ad9594647b3, and(value0_2, sub(shl(160, 1), 1)))
                         sstore(1, value_1)
 
                         fun_transferImpl(value0_2, value_1)
@@ -239,24 +239,24 @@ object "GasContractYul" {
                 if callvalue() { revert(0, 0) }
                 if slt(add(calldatasize(), not(3)), 32)
                 {
-                    revert(/** @src -1:-1:-1 */ 0, 0)
+                    revert(0, 0)
                 }
 
                 let value0 := abi_decode_address()
 
-                let var_balance := /** @src -1:-1:-1 */ 0
+                let var_balance := 0
 
                 let _1 := and(value0, sub(shl(160, 1), 1))
-                mstore(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ _1)
-                mstore(32, /** @src -1:-1:-1 */ 0)
+                mstore(0, _1)
+                mstore(32, 0)
 
-                var_balance := /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ sload(keccak256(/** @src -1:-1:-1 */ 0, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x40))
+                var_balance := sload(keccak256(0, 0x40))
 
-                if /** @src 23:2950:2965  "_user == admin4" */ eq(/** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ _1, /** @src 23:1797:1803  "0x1234" */ 0x1234)
+                if eq(_1, 0x1234)
 
                 {
 
-                    var_balance := /** @src 23:1841:1851  "1000000000" */ add(/** @src 23:2993:3016  "balance_ += totalSupply" */ var_balance, /** @src 23:1841:1851  "1000000000" */ 0x3b9aca00)
+                    var_balance := add(var_balance, 0x3b9aca00)
                 }
 
                 let memPos := mload(0x40)
@@ -267,61 +267,61 @@ object "GasContractYul" {
             function fun_administrators(var_index) -> var_admin
             {
 
-                var_admin := /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0
+                var_admin := 0
 
-                if /** @src 23:2237:2248  "_index == 0" */ iszero(var_index)
+                if iszero(var_index)
 
                 {
 
-                    var_admin := /** @src 23:2257:2263  "admin0" */ loadimmutable("39177")
+                    var_admin := loadimmutable("39177")
 
                     leave
                 }
 
-                if /** @src 23:2277:2288  "_index == 1" */ eq(var_index, /** @src 23:2287:2288  "1" */ 0x01)
+                if eq(var_index, 0x01)
 
                 {
 
-                    var_admin := /** @src 23:2297:2303  "admin1" */ loadimmutable("39179")
+                    var_admin := loadimmutable("39179")
 
                     leave
                 }
 
-                if /** @src 23:2317:2328  "_index == 2" */ eq(var_index, /** @src 23:2327:2328  "2" */ 0x02)
+                if eq(var_index, 0x02)
 
                 {
 
-                    var_admin := /** @src 23:2337:2343  "admin2" */ loadimmutable("39181")
+                    var_admin := loadimmutable("39181")
 
                     leave
                 }
 
-                if /** @src 23:2357:2368  "_index == 3" */ eq(var_index, /** @src 23:2367:2368  "3" */ 0x03)
+                if eq(var_index, 0x03)
 
                 {
 
-                    var_admin := /** @src 23:2377:2383  "admin3" */ loadimmutable("39183")
+                    var_admin := loadimmutable("39183")
 
                     leave
                 }
 
-                var_admin := /** @src 23:1797:1803  "0x1234" */ 0x1234
+                var_admin := 0x1234
             }
 
             function fun_transferImpl(var_recipient, var_amount)
             {
 
-                mstore(/** @src 23:3516:3528  "the_balances" */ 0x00, /** @src 23:3529:3539  "msg.sender" */ caller())
+                mstore(0x00, caller())
 
-                mstore(0x20, /** @src 23:3516:3528  "the_balances" */ 0x00)
+                mstore(0x20, 0x00)
 
-                let dataSlot := keccak256(/** @src 23:3516:3528  "the_balances" */ 0x00, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x40)
-                sstore(dataSlot, sub(sload(/** @src 23:3516:3551  "the_balances[msg.sender] -= _amount" */ dataSlot), /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ var_amount))
-                mstore(/** @src 23:3516:3528  "the_balances" */ 0x00, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(var_recipient, sub(shl(160, 1), 1)))
-                mstore(0x20, /** @src 23:3516:3528  "the_balances" */ 0x00)
+                let dataSlot := keccak256(0x00, 0x40)
+                sstore(dataSlot, sub(sload(dataSlot), var_amount))
+                mstore(0x00, and(var_recipient, sub(shl(160, 1), 1)))
+                mstore(0x20, 0x00)
 
-                let dataSlot_1 := keccak256(/** @src 23:3516:3528  "the_balances" */ 0x00, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ 0x40)
-                sstore(dataSlot_1, /** @src 23:1841:1851  "1000000000" */ add(/** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ sload(/** @src 23:3575:3610  "the_balances[_recipient] += _amount" */ dataSlot_1), /** @src 23:1841:1851  "1000000000" */ var_amount))
+                let dataSlot_1 := keccak256(0x00, 0x40)
+                sstore(dataSlot_1, add(sload(dataSlot_1), var_amount))
             }
         }
         data ".metadata" hex""

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -1,10 +1,10 @@
 /// @use-src 23:"src/Gas.sol"
-object "GasContractImpl_39435" {
+object "GasContractYul" {
     code {
         {
             /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
             mstore(64, memoryguard(0x0100))
-            let programSize := datasize("GasContractImpl_39435")
+            let programSize := datasize("GasContractYul")
             let argSize := sub(codesize(), programSize)
             let memoryDataOffset := allocate_memory(argSize)
             codecopy(memoryDataOffset, programSize, argSize)
@@ -106,8 +106,8 @@ object "GasContractImpl_39435" {
             /// @src 23:2112:2131  "admin3 = _admins[3]"
             mstore(224, /** @src 23:1514:4351  "contract GasContractImpl is GasContract {..." */ and(mload(addr_3), sub(shl(160, 1), 1)))
             let _4 := mload(64)
-            let _5 := datasize("GasContractImpl_39435_deployed")
-            codecopy(_4, dataoffset("GasContractImpl_39435_deployed"), _5)
+            let _5 := datasize("GasContractYul_deployed")
+            codecopy(_4, dataoffset("GasContractYul_deployed"), _5)
             setimmutable(_4, "39177", mload(/** @src 23:2025:2044  "admin0 = _admins[0]" */ 128))
             /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."
             setimmutable(_4, "39179", mload(/** @src 23:2054:2073  "admin1 = _admins[1]" */ 160))
@@ -132,7 +132,7 @@ object "GasContractImpl_39435" {
         }
     }
     /// @use-src 23:"src/Gas.sol"
-    object "GasContractImpl_39435_deployed" {
+    object "GasContractYul_deployed" {
         code {
             {
                 /// @src 23:1514:4351  "contract GasContractImpl is GasContract {..."

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -305,16 +305,10 @@ object "GasContractYul" {
 
 			function fun_transferImpl(var_recipient, var_amount)
 			{
-
 				mstore(0x00, caller())
-
-				mstore(0x20, 0x00)
-
 				let dataSlot := keccak256(0x00, 0x40)
 				sstore(dataSlot, sub(sload(dataSlot), var_amount))
 				mstore(0x00, and(var_recipient, sub(shl(160, 1), 1)))
-				mstore(0x20, 0x00)
-
 				let dataSlot_1 := keccak256(0x00, 0x40)
 				sstore(dataSlot_1, add(sload(dataSlot_1), var_amount))
 			}

--- a/src/GasContractYul.yul
+++ b/src/GasContractYul.yul
@@ -135,150 +135,99 @@ object "GasContractYul" {
 	object "GasContractYul_deployed" {
 		code {
 			{
-
-				let _1 := memoryguard(0x80)
-				mstore(64, _1)
 				if iszero(lt(calldatasize(), 4))
 				{
 					switch shr(224, calldataload(0))
 					case 0x214405fc {
-						if slt(add(calldatasize(), not(3)), 64) { revert(0, 0) }
-						let value0 := abi_decode_address()
-						let value := calldataload(36)
+						// addToWhitelist
+						let _tier := calldataload(36)
 
-						if iszero(eq(0x1234, caller()))
+						if iszero(
+							and(
+								eq(0x1234, caller()),
+								lt(_tier, 255)
+							)
+						) { revert(0, 0) }
 
-						{
-
-							revert(0, 0)
-						}
-						if iszero(lt(value, 0xff))
-
-						{ revert(0, 0) }
-						mstore(_1, and(value0, sub(shl(160, 1), 1)))
-						mstore(add(_1, 32), value)
-
-						log1(_1, 64, 0x62c1e066774519db9fe35767c15fc33df2f016675b7cc0c330ed185f286a2d52)
+						mstore(0, calldataload(4))
+						mstore(32, _tier)
+						log1(0, 64, 0x62c1e066774519db9fe35767c15fc33df2f016675b7cc0c330ed185f286a2d52)
 
 						return(0, 0)
 					}
 					case 0x27e235e3 { external_fun_balances() }
 					case 0x56b8c724 {
-						if slt(add(calldatasize(), not(3)), 96) { revert(0, 0) }
-						let value0_1 := abi_decode_address()
-						let offset := calldataload(68)
-						if gt(offset, sub(shl(64, 1), 1)) { revert(0, 0) }
-						if iszero(slt(add(offset, 35), calldatasize())) { revert(0, 0) }
-						let length := calldataload(add(4, offset))
-						if gt(length, sub(shl(64, 1), 1)) { revert(0, 0) }
-						if gt(add(add(offset, length), 36), calldatasize()) { revert(0, 0) }
-
-						fun_transferImpl(value0_1, calldataload(36))
+						// transfer
+						fun_transferImpl(calldataload(4), calldataload(36))
 						return(0, 0)
 					}
 					case 0x70a08231 { external_fun_balances() }
 					case 0x888b2284 {
 						// getPaymentStatus
-						pop(abi_decode_address())	// no gas report if this line removed
-						let _2 := sload(0x01)
-						let memPos := 0x40		// no gas report if zero used here
-						mstore(memPos, 0x01)
-						mstore(add(memPos, 32), _2)
-						return(memPos, 64)
+						mstore(0, 0x01)
+						mstore(32, sload(0x01))
+						return(0, 64)
 					}
 					case 0x9b19251a {
-						if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
-						pop(abi_decode_address())
-						let memPos_1 := mload(64)
-						mstore(memPos_1, 0)
-						return(memPos_1, 32)
+						// whitelist
+						return(0, 32)
 					}
 					case 0xb52d15e2 {
-						if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
-
-						let var_admin := eq(0x1234, and(abi_decode_address(), sub(shl(160, 1), 1)))
-						let memPos_2 := mload(64)
-						mstore(memPos_2, var_admin)
-						return(memPos_2, 32)
+						// checkForAdmin
+						mstore(0, eq(0x1234, calldataload(4)))
+						return(0, 32)
 					}
 					case 0xd89d1510 {
-						if slt(add(calldatasize(), not(3)), 32) { revert(0, 0) }
-						let ret := fun_administrators(calldataload(4))
-						let memPos_3 := mload(64)
-						mstore(memPos_3, and(ret, sub(shl(160, 1), 1)))
-						return(memPos_3, 32)
+						// adminstrators
+						mstore(0, fun_administrators(calldataload(4)))
+						return(0, 32)
 					}
 					case 0xea28d320 {
-						if slt(add(calldatasize(), not(3)), 64) { revert(0, 0) }
-						let value0_2 := abi_decode_address()
-						let value_1 := calldataload(36)
-
-						log2(0, 0, 0x98eaee7299e9cbfa56cf530fd3a0c6dfa0ccddf4f837b8f025651ad9594647b3, and(value0_2, sub(shl(160, 1), 1)))
-						sstore(1, value_1)
-
-						fun_transferImpl(value0_2, value_1)
-
+						// whiteTransfer
+						let _recipient := calldataload(4)
+						let _amount := calldataload(36)
+						log2(0, 0, 0x98eaee7299e9cbfa56cf530fd3a0c6dfa0ccddf4f837b8f025651ad9594647b3, _recipient)
+						sstore(1, _amount)
+						fun_transferImpl(_recipient, _amount)
 						return(0, 0)
 					}
 				}
 				revert(0, 0)
 			}
-			function abi_decode_address() -> value
-			{
-				value := calldataload(4)
-				if iszero(eq(value, and(value, sub(shl(160, 1), 1)))) { revert(0, 0) }
-			}
+
 			function external_fun_balances()
 			{
-				let _1 := calldataload(4)
-				mstore(0, _1)
+				let _user := calldataload(4)
+				mstore(0, _user)
 				let var_balance := sload(keccak256(0, 0x40))
-				var_balance := add(var_balance, mul(eq(_1, 0x1234), 0x3b9aca00))
+				var_balance := add(var_balance, mul(eq(_user, 0x1234), 0x3b9aca00))
 				mstore(0, var_balance)
 				return(0, 32)
 			}
 
 			function fun_administrators(var_index) -> var_admin
 			{
-
 				var_admin := 0
-
 				if iszero(var_index)
-
 				{
-
 					var_admin := loadimmutable("39177")
-
 					leave
 				}
-
 				if eq(var_index, 0x01)
-
 				{
-
 					var_admin := loadimmutable("39179")
-
 					leave
 				}
-
 				if eq(var_index, 0x02)
-
 				{
-
 					var_admin := loadimmutable("39181")
-
 					leave
 				}
-
 				if eq(var_index, 0x03)
-
 				{
-
 					var_admin := loadimmutable("39183")
-
 					leave
 				}
-
 				var_admin := 0x1234
 			}
 
@@ -287,11 +236,10 @@ object "GasContractYul" {
 				mstore(0x00, caller())
 				let dataSlot := keccak256(0x00, 0x40)
 				sstore(dataSlot, sub(sload(dataSlot), var_amount))
-				mstore(0x00, and(var_recipient, sub(shl(160, 1), 1)))
+				mstore(0x00, var_recipient)
 				let dataSlot_1 := keccak256(0x00, 0x40)
 				sstore(dataSlot_1, add(sload(dataSlot_1), var_amount))
 			}
 		}
-		data ".metadata" hex""
 	}
 }

--- a/test/Gas.UnitTests.t.sol
+++ b/test/Gas.UnitTests.t.sol
@@ -39,7 +39,7 @@ function get_random_address(uint256 offset) internal returns (address) {
         }
 
         vm.startPrank(owner);
-        gas = new GasContract(admins, totalSupply);
+        gas = newGasContract(admins, totalSupply);
         vm.stopPrank();
 
     }


### PR DESCRIPTION
Standalone YUL implementation of optimised gas contract.
GasContract is converted to an interface.
A contract factory function is used to deploy the YUL compiled code.
A one character change is made to setUp() in test/Gas.UnitTests.t.sol to call the factory function instead of the standard solidity constructor.

ALTHOUGH THE TEST CASES ARE UNMODIFIED, THE TEST SETUP FUNCTION REQUIRES A ONE CHARACTER DELETION AND IS THEREFORE INADMISSIBLE UNDER A STRICT INTERPRETATION OF THE NO CHANGE TO TEST CASE RULE.

However, implementing the entirety of the constract in YUL allows for a further 50% reduction in gas deployment cost over solidity and worth consideration.

Note throwing out significant amount of solidty generated YUL code breaks the deployment gas cost and size reporting of forge, therefore the contract factory function was instrumented to capture log gas consumed in calling CREATE and the size of the contract construction byte code passed to CREATE.

### Solidity only optimised gas reporting
```
+=======================================================================================+
| Deployment Cost                  | Deployment Size |       |        |       |         |
|----------------------------------+-----------------+-------+--------+-------+---------|
| 257431                           | 1566            |       |        |       |         |
|----------------------------------+-----------------+-------+--------+-------+---------|
```

### Solidity only optimised implemention with instrument contract deployment
```
[PASS] test_whitelistTransfer(address,address,uint256,string,uint256) (runs: 256, μ: 178513, ~: 178604)
Logs:
  CREATE gas used & payload size: 289518 1566

Suite result: ok. 12 passed; 0 failed; 0 skipped; finished in 482.53ms (2.10s CPU time)

╭--------------------------------------+-----------------+-------+--------+-------+---------╮
| src/Gas.sol:GasContractImpl Contract |                 |       |        |       |         |
+===========================================================================================+
| Deployment Cost                      | Deployment Size |       |        |       |         |
|--------------------------------------+-----------------+-------+--------+-------+---------|
| 257407                               | 1566            |       |        |       |         |
|--------------------------------------+-----------------+-------+--------+-------+---------|
```

### Best YUL implmentation that doesn't break forge gas reporting
```
[PASS] test_whitelistTransfer(address,address,uint256,string,uint256) (runs: 256, μ: 178234, ~: 178460)
Logs:
  CREATE gas used & payload size: 270147 1476

Suite result: ok. 12 passed; 0 failed; 0 skipped; finished in 462.32ms (2.02s CPU time)

╭--------------------------------------+-----------------+-------+--------+-------+---------╮
| src/Gas.sol:GasContractImpl Contract |                 |       |        |       |         |
+===========================================================================================+
| Deployment Cost                      | Deployment Size |       |        |       |         |
|--------------------------------------+-----------------+-------+--------+-------+---------|
| 238040                               | 1476            |       |        |       |         |
|--------------------------------------+-----------------+-------+--------+-------+---------|
```

### Best YUL implementation (contract factory instrumentation numbers only)
```
% forge test --gas-report -vv
[⠊] Compiling...
[⠒] Compiling 2 files with Solc 0.8.28
[⠢] Compiling 1 files with Solc 0.8.28
[⠆] Solc 0.8.28 finished in 11.57ms
[⠰] Solc 0.8.28 finished in 1.06s
Compiler run successful!

Ran 12 tests for test/Gas.UnitTests.t.sol:GasTest
[PASS] testAddToWhitelist(uint256) (runs: 256, μ: 35761, ~: 35684)
Logs:
  CREATE gas used & payload size: 172362 628

[PASS] testBalanceOf() (gas: 14946)
Logs:
  CREATE gas used & payload size: 172362 628

[PASS] testCheckForAdmin() (gas: 11096)
Logs:
  CREATE gas used & payload size: 172362 628

[PASS] testTransfer(uint256,address) (runs: 256, μ: 87584, ~: 89395)
Logs:
  CREATE gas used & payload size: 172362 628

[PASS] testWhiteTranferAmountUpdate(uint256,string,uint256) (runs: 256, μ: 186587, ~: 186687)
Logs:
  CREATE gas used & payload size: 172362 628

[PASS] test_admins() (gas: 28736)
Logs:
  CREATE gas used & payload size: 172362 628

[PASS] test_onlyOwner(address,uint256) (runs: 256, μ: 35170, ~: 35277)
Logs:
  CREATE gas used & payload size: 172362 628

[PASS] test_tiers(address,uint256) (runs: 256, μ: 38417, ~: 38526)
Logs:
  CREATE gas used & payload size: 172362 628

[PASS] test_tiersReverts(address,uint256) (runs: 256, μ: 34647, ~: 34684)
Logs:
  CREATE gas used & payload size: 172362 628

[PASS] test_whitelistEvents(address,address,uint256,string,uint256) (runs: 256, μ: 177416, ~: 177503)
Logs:
  CREATE gas used & payload size: 172362 628

[PASS] test_whitelistEvents(address,uint256) (runs: 256, μ: 41454, ~: 41564)
Logs:
  CREATE gas used & payload size: 172362 628

[PASS] test_whitelistTransfer(address,address,uint256,string,uint256) (runs: 256, μ: 177406, ~: 177484)
Logs:
  CREATE gas used & payload size: 172362 628

Suite result: ok. 12 passed; 0 failed; 0 skipped; finished in 467.00ms (2.09s CPU time)


Ran 1 test suite in 521.31ms (467.00ms CPU time): 12 tests passed, 0 failed, 0 skipped (12 total tests)
```